### PR TITLE
Fix README.md

### DIFF
--- a/Docs/README.md
+++ b/Docs/README.md
@@ -16,7 +16,7 @@ If cicp_inserter is missing a feature you need, submit a [feature request](https
 ## Dependencies
 
 cicp_inserter depends on [max](https://github.com/ProgramMax/max), which also has a [BSD 3-Clause license](https://github.com/ProgramMax/max/blob/master/LICENSE).
-You can find some parts of max under [Dependencies/max](https://github.com/ProgramMax/maxGUI/blob/master/Dependencies/max).
+You can find some parts of max under [Dependencies/max](https://github.com/ProgramMax/cicp_inserter/blob/master/Dependencies/max).
 
 ## Engage
 


### PR DESCRIPTION
I pulled the README.md from another project of mine. And in doing so, I left a link to the old project.

This commit corrects the link to reference this project.