### PR TITLE
Format README.md command line example

### DIFF
--- a/Docs/README.md
+++ b/Docs/README.md
@@ -3,7 +3,7 @@
 cicp_inserter allows for easy insertion of CICP data into a PNG file.
 
 A typical use case looks like this:
-cicp_inserter.exe --preset display-p3 C:\images\test.png
+`cicp_inserter.exe --preset display-p3 C:\images\test.png`
 
 This command updates the file to use Display P3.
 It does not update or alter any color values.
@@ -15,7 +15,7 @@ If cicp_inserter is missing a feature you need, submit a [feature request](https
 
 ## Dependencies
 
-cicp_inserter depends on [max](https://github.com/ProgramMax/max), which also has a [BSD 3-Clause license](https://github.com/ProgramMax/max/blob/master/LICENSE).
+cicp_inserter has no dependencies beyond the C and C++ standard libraries. However, the tests depend on [max](https://github.com/ProgramMax/max), which also has a [BSD 3-Clause license](https://github.com/ProgramMax/max/blob/master/LICENSE).
 You can find some parts of max under [Dependencies/max](https://github.com/ProgramMax/cicp_inserter/blob/master/Dependencies/max).
 
 ## Engage


### PR DESCRIPTION
The command line example appeared inline with regular text. This commit separates it and changes its display, which should help convey that it is a command line.