### PR TITLE
Add Error type

### DIFF
--- a/Code/cicp_inserter/CICPInserter.cpp
+++ b/Code/cicp_inserter/CICPInserter.cpp
@@ -32,11 +32,6 @@ namespace {
 
 namespace CICP_Inserter {
 
-	GetInsertionIndexError::GetInsertionIndexError(GetInsertionIndexErrorCode error_code, std::vector<std::string_view> output_messages) noexcept
-		: error_code_(std::move(error_code))
-		, output_messages_(std::move(output_messages))
-	{}
-
 	std::expected<size_t, GetInsertionIndexError> get_insertion_index(const std::span<char>& file_contents, const std::vector<size_t>& chunk_indices) noexcept {
 		auto plte_index = size_t{ SIZE_MAX };
 		auto idat_index = size_t{ SIZE_MAX };

--- a/Code/cicp_inserter/CICPInserter.hpp
+++ b/Code/cicp_inserter/CICPInserter.hpp
@@ -2,10 +2,15 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#ifndef CICP_INSERTER_CICPINSERTER_HPP
+#define CICP_INSERTER_CICPINSERTER_HPP
+
 #include <expected>
 #include <span>
 #include <string_view>
 #include <vector>
+
+#include "Error.hpp"
 
 namespace CICP_Inserter {
 
@@ -13,17 +18,10 @@ namespace CICP_Inserter {
 		CICPChunkAlreadyExists,
 		CouldNotFindInsertionPoint,
 	};
-
-	class GetInsertionIndexError {
-	public:
-
-		explicit GetInsertionIndexError(GetInsertionIndexErrorCode error_code, std::vector<std::string_view> output_messages) noexcept;
-
-		GetInsertionIndexErrorCode error_code_;
-		std::vector<std::string_view> output_messages_;
-
-	};
+	using GetInsertionIndexError = ErrorWithCode<GetInsertionIndexErrorCode>;
 
 	std::expected<size_t, GetInsertionIndexError> get_insertion_index(const std::span<char>& file_contents, const std::vector<size_t>& chunk_indices) noexcept;
 
 } // namespace CICP_Inserter
+
+#endif // #ifndef CICP_INSERTER_CICPINSERTER_HPP

--- a/Code/cicp_inserter/CommandLineParameters.cpp
+++ b/Code/cicp_inserter/CommandLineParameters.cpp
@@ -79,19 +79,7 @@ Example usage: cicp_inserter.exe --preset display-p3 --video_full_range_flag 0 C
 		UnrecognizedParameter,
 		ValueOutsideRange,
 	};
-
-	class ReadNumericValueError {
-	public:
-
-		explicit ReadNumericValueError(ReadNumericValueErrorCode error_code, std::vector<char const*> output_messages) noexcept
-			: error_code_(std::move(error_code))
-			, output_messages_(std::move(output_messages))
-		{}
-
-		ReadNumericValueErrorCode error_code_;
-		std::vector<char const*> output_messages_;
-
-	};
+	using ReadNumericValueError = CICP_Inserter::ErrorWithCode<ReadNumericValueErrorCode>;
 
 	std::expected<uint8_t, ReadNumericValueError> read_numeric_value(char const* parameter) noexcept {
 		static constinit int base = 10;
@@ -132,11 +120,6 @@ namespace CICP_Inserter {
 		, matrix_coefficients_(std::move(matrix_coefficients))
 		, video_full_range_flag_(std::move(video_full_range_flag))
 		, png_file_path_(std::move(png_file_path))
-	{}
-
-	ParseCommandLineParametersError::ParseCommandLineParametersError(ParseCommandLineParametersErrorCode error_code, std::vector<char const*> output_messages) noexcept
-		: error_code_(std::move(error_code))
-		, output_messages_(std::move(output_messages))
 	{}
 
 	std::expected<CommandLineParameters, ParseCommandLineParametersError> parse_command_line_parameters(int argc, char const* argv[]) noexcept {

--- a/Code/cicp_inserter/CommandLineParameters.hpp
+++ b/Code/cicp_inserter/CommandLineParameters.hpp
@@ -11,6 +11,8 @@
 #include <utility>
 #include <vector>
 
+#include "Error.hpp"
+
 namespace CICP_Inserter {
 
 	class CommandLineParameters {
@@ -32,16 +34,7 @@ namespace CICP_Inserter {
 		ExpectedValue,
 		NotActuallyAnError, // TODO: Find a good way to separate actions (--help, --version) from returning a CommandLineParameters and remove this
 	};
-
-	class ParseCommandLineParametersError {
-	public:
-
-		explicit ParseCommandLineParametersError(ParseCommandLineParametersErrorCode error_code, std::vector<char const*> output_messages) noexcept;
-
-		ParseCommandLineParametersErrorCode error_code_;
-		std::vector<char const*> output_messages_;
-
-	};
+	using ParseCommandLineParametersError = ErrorWithCode<ParseCommandLineParametersErrorCode>;
 
 	std::expected<CommandLineParameters, ParseCommandLineParametersError> parse_command_line_parameters(int argc, char const* argv[]) noexcept;
 

--- a/Code/cicp_inserter/EntryPoint.cpp
+++ b/Code/cicp_inserter/EntryPoint.cpp
@@ -6,20 +6,10 @@
 
 #include "CICPInserter.hpp"
 #include "CommandLineParameters.hpp"
+#include "Error.hpp"
 #include "FileReader.hpp"
 #include "FileWriter.hpp"
 #include "PNGParser.hpp"
-
-namespace {
-
-	template<typename T>
-	void print_error(T error) noexcept {
-		for (auto& message : error.output_messages_) {
-			std::cerr << message;
-		}
-	}
-
-} // anonymous namespace
 
 int main(int argc, char const* argv[]) noexcept {
 	// Parse the command line parameters
@@ -29,7 +19,7 @@ int main(int argc, char const* argv[]) noexcept {
 			return 0;
 		}
 
-		print_error(std::move(command_line_parameters.error()));
+		print_error(command_line_parameters.error());
 		return 1;
 	}
 

--- a/Code/cicp_inserter/Error.cpp
+++ b/Code/cicp_inserter/Error.cpp
@@ -1,0 +1,22 @@
+// Copyright 2025, The cicp_inserter Contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "Error.hpp"
+
+#include <iostream>
+
+namespace CICP_Inserter {
+
+	Error::Error(std::vector<std::string_view> output_messages) noexcept
+		: output_messages_(std::move(output_messages))
+	{
+	}
+
+	void print_error(const Error& error) noexcept {
+		for (auto& message : error.output_messages_) {
+			std::cerr << message;
+		}
+	}
+
+} // namespace CICP_Inserter

--- a/Code/cicp_inserter/Error.hpp
+++ b/Code/cicp_inserter/Error.hpp
@@ -1,0 +1,40 @@
+// Copyright 2025, The cicp_inserter Contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CICP_INSERTER_ERROR_HPP
+#define CICP_INSERTER_ERROR_HPP
+
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace CICP_Inserter {
+
+	class Error {
+	public:
+
+		explicit Error(std::vector<std::string_view> output_messages) noexcept;
+
+		std::vector<std::string_view> output_messages_;
+
+	};
+
+	void print_error(const Error& error) noexcept;
+
+	template<typename T>
+	class ErrorWithCode : public Error {
+	public:
+
+		explicit ErrorWithCode(T error_code, std::vector<std::string_view> output_messages) noexcept
+			: Error(std::move(output_messages))
+			, error_code_(std::move(error_code))
+		{}
+
+		T error_code_;
+
+	};
+
+} // namespace CICP_Inserter
+
+#endif // #ifndef CICP_INSERTER_ERROR_HPP

--- a/Code/cicp_inserter/FileReader.cpp
+++ b/Code/cicp_inserter/FileReader.cpp
@@ -21,11 +21,6 @@ namespace {
 
 namespace CICP_Inserter {
 
-	ReadFileError::ReadFileError(ReadFileErrorCode error_code, std::vector<std::string_view> output_messages) noexcept
-		: error_code_(std::move(error_code))
-		, output_messages_(std::move(output_messages))
-	{}
-
 	std::expected<std::vector<char>, ReadFileError> read_file(const std::string& file_path) noexcept {
 		// TODO: Do I really need filesystem here?
 		// The parameter should be a filesystem::path.

--- a/Code/cicp_inserter/FileReader.hpp
+++ b/Code/cicp_inserter/FileReader.hpp
@@ -10,22 +10,15 @@
 #include <string_view>
 #include <vector>
 
+#include "Error.hpp"
+
 namespace CICP_Inserter {
 
 	enum class ReadFileErrorCode {
 		CannotOpenFile,
 		CannotReadFile,
 	};
-
-	class ReadFileError {
-	public:
-
-		explicit ReadFileError(ReadFileErrorCode error_code, std::vector<std::string_view> output_messages) noexcept;
-
-		ReadFileErrorCode error_code_;
-		std::vector<std::string_view> output_messages_;
-
-	};
+	using ReadFileError = ErrorWithCode<ReadFileErrorCode>;
 
 	std::expected<std::vector<char>, ReadFileError> read_file(const std::string& file_path) noexcept;
 

--- a/Code/cicp_inserter/FileWriter.cpp
+++ b/Code/cicp_inserter/FileWriter.cpp
@@ -21,12 +21,6 @@ namespace {
 
 namespace CICP_Inserter {
 
-	WriteFileError::WriteFileError(WriteFileErrorCode error_code, std::vector<std::string_view> output_messages) noexcept
-		: error_code_(std::move(error_code))
-		, output_messages_(std::move(output_messages))
-	{
-	}
-
 	std::expected<void, WriteFileError> write_file(const std::string& file_path, std::vector<std::span<char>> buffers) noexcept {
 		// TODO: Do I really need filesystem here?
 		// The parameter should be a filesystem::path.
@@ -47,6 +41,8 @@ namespace CICP_Inserter {
 		}
 
 		png_file.close();
+
+		return std::expected<void, WriteFileError>{};
 	}
 
 } // namespace CICP_Inserter

--- a/Code/cicp_inserter/FileWriter.hpp
+++ b/Code/cicp_inserter/FileWriter.hpp
@@ -11,22 +11,15 @@
 #include <string_view>
 #include <vector>
 
+#include "Error.hpp"
+
 namespace CICP_Inserter {
 
 	enum class WriteFileErrorCode {
 		CannotOpenFile,
 		CannotWriteFile,
 	};
-
-	class WriteFileError {
-	public:
-
-		explicit WriteFileError(WriteFileErrorCode error_code, std::vector<std::string_view> output_messages) noexcept;
-
-		WriteFileErrorCode error_code_;
-		std::vector<std::string_view> output_messages_;
-
-	};
+	using WriteFileError = ErrorWithCode<WriteFileErrorCode>;
 
 	std::expected<void, WriteFileError> write_file(const std::string& file_path, std::vector<std::span<char>> buffers) noexcept;
 

--- a/Code/cicp_inserter/PNGParser.cpp
+++ b/Code/cicp_inserter/PNGParser.cpp
@@ -34,11 +34,6 @@ namespace {
 
 namespace CICP_Inserter {
 
-	GetChunkIndicesError::GetChunkIndicesError(GetChunkIndicesErrorCode error_code, std::vector<std::string_view> output_messages) noexcept
-		: error_code_(std::move(error_code))
-		, output_messages_(std::move(output_messages))
-	{}
-
 	std::expected<std::vector<size_t>, GetChunkIndicesError> get_chunk_indices(const std::span<char>& file_contents) noexcept {
 		if (png_header.compare(file_contents.data()) != 0) {
 			return std::unexpected{ GetChunkIndicesError{ GetChunkIndicesErrorCode::NotAPNGFile, { not_a_png_file } } };

--- a/Code/cicp_inserter/PNGParser.hpp
+++ b/Code/cicp_inserter/PNGParser.hpp
@@ -2,27 +2,25 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#ifndef CICP_INSERTER_PNGPARSER_HPP
+#define CICP_INSERTER_PNGPARSER_HPP
+
 #include <expected>
 #include <span>
 #include <string_view>
 #include <vector>
+
+#include "Error.hpp"
 
 namespace CICP_Inserter {
 
 	enum class GetChunkIndicesErrorCode {
 		NotAPNGFile,
 	};
-
-	class GetChunkIndicesError {
-	public:
-
-		explicit GetChunkIndicesError(GetChunkIndicesErrorCode error_code, std::vector<std::string_view> output_messages) noexcept;
-
-		GetChunkIndicesErrorCode error_code_;
-		std::vector<std::string_view> output_messages_;
-
-	};
+	using GetChunkIndicesError = ErrorWithCode<GetChunkIndicesErrorCode>;
 
 	std::expected<std::vector<size_t>, GetChunkIndicesError> get_chunk_indices(const std::span<char>& file_contents) noexcept;
 
 } // namespace CICP_Inserter
+
+#endif // #ifndef CICP_INSERTER_PNGPARSER_HPP

--- a/Code/tests/EntryPoint.cpp
+++ b/Code/tests/EntryPoint.cpp
@@ -4,6 +4,7 @@
 
 #include "CICPInserterTest.hpp"
 #include "CommandLineParametersTest.hpp"
+#include "ErrorTest.hpp"
 #include "FileReaderTest.hpp"
 #include "FileWriterTest.hpp"
 #include "PNGParserTest.hpp"
@@ -11,6 +12,7 @@
 int main() {
 	CICP_Inserter::RunCICPInserterTestSuite();
 	CICP_Inserter::RunCommandLineParametersTestSuite();
+	CICP_Inserter::RunErrorTestSuite();
 	CICP_Inserter::RunFileReaderTestSuite();
 	CICP_Inserter::RunFileWriterTestSuite();
 	CICP_Inserter::RunPNGParserTestSuite();

--- a/Code/tests/ErrorTest.cpp
+++ b/Code/tests/ErrorTest.cpp
@@ -1,0 +1,46 @@
+// Copyright 2025, The cicp_inserter Contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ErrorTest.hpp"
+
+#include <utility>
+
+#include <Error.hpp>
+#include <max/Testing/TestSuite.hpp>
+#include <max/Testing/CoutResultPolicy.hpp>
+
+namespace {
+
+	static constinit char const* test_string = "test string";
+
+} // anonymous namespace
+
+namespace CICP_Inserter {
+
+	void RunErrorTestSuite()
+	{
+		max::Testing::CoutResultPolicy ResultPolicy;
+		auto ErrorTestSuite = max::Testing::TestSuite< max::Testing::CoutResultPolicy >{ "Error test suite", std::move(ResultPolicy) };
+
+		ErrorTestSuite.AddTest(max::Testing::Test< max::Testing::CoutResultPolicy >{ "Error ctor assigns members", [](max::Testing::Test< max::Testing::CoutResultPolicy >& CurrentTest, max::Testing::CoutResultPolicy const& ResultPolicy) {
+			auto error = Error{ { test_string } };
+
+			CurrentTest.MAX_TESTING_ASSERT(error.output_messages_.size() == 1);
+			CurrentTest.MAX_TESTING_ASSERT(error.output_messages_[0] == test_string);
+			}
+		});
+
+		ErrorTestSuite.AddTest(max::Testing::Test< max::Testing::CoutResultPolicy >{ "ErrorWithCode ctor assigns members", [](max::Testing::Test< max::Testing::CoutResultPolicy >& CurrentTest, max::Testing::CoutResultPolicy const& ResultPolicy) {
+			auto error = ErrorWithCode<int>{ 1, { test_string } };
+
+			CurrentTest.MAX_TESTING_ASSERT(error.error_code_ == 1);
+			CurrentTest.MAX_TESTING_ASSERT(error.output_messages_.size() == 1);
+			CurrentTest.MAX_TESTING_ASSERT(error.output_messages_[0] == test_string);
+			}
+		});
+
+		ErrorTestSuite.RunTests();
+	}
+
+} // namespace CICP_Inserter

--- a/Code/tests/ErrorTest.hpp
+++ b/Code/tests/ErrorTest.hpp
@@ -1,0 +1,14 @@
+// Copyright 2025, The cicp_inserter Contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CICP_INSERTER_ERRORTEST_HPP
+#define CICP_INSERTER_ERRORTEST_HPP
+
+namespace CICP_Inserter {
+
+	void RunErrorTestSuite();
+
+} // namespace CICP_Inserter
+
+#endif // #ifndef CICP_INSERTER_ERRORTEST_HPP

--- a/Projects/VisualStudio/cicp_inserter.vcxproj
+++ b/Projects/VisualStudio/cicp_inserter.vcxproj
@@ -32,6 +32,7 @@
     <ClCompile Include="..\..\Code\cicp_inserter\CICPInserter.cpp" />
     <ClCompile Include="..\..\Code\cicp_inserter\CommandLineParameters.cpp" />
     <ClCompile Include="..\..\Code\cicp_inserter\EntryPoint.cpp" />
+    <ClCompile Include="..\..\Code\cicp_inserter\Error.cpp" />
     <ClCompile Include="..\..\Code\cicp_inserter\FileReader.cpp" />
     <ClCompile Include="..\..\Code\cicp_inserter\FileWriter.cpp" />
     <ClCompile Include="..\..\Code\cicp_inserter\PNGParser.cpp" />
@@ -39,6 +40,7 @@
   <ItemGroup>
     <ClInclude Include="..\..\Code\cicp_inserter\CICPInserter.hpp" />
     <ClInclude Include="..\..\Code\cicp_inserter\CommandLineParameters.hpp" />
+    <ClInclude Include="..\..\Code\cicp_inserter\Error.hpp" />
     <ClInclude Include="..\..\Code\cicp_inserter\FileReader.hpp" />
     <ClInclude Include="..\..\Code\cicp_inserter\FileWriter.hpp" />
     <ClInclude Include="..\..\Code\cicp_inserter\PNGParser.hpp" />

--- a/Projects/VisualStudio/cicp_inserter.vcxproj.filters
+++ b/Projects/VisualStudio/cicp_inserter.vcxproj.filters
@@ -56,6 +56,9 @@
     <ClCompile Include="..\..\Code\cicp_inserter\FileWriter.cpp">
       <Filter>Code</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Code\cicp_inserter\Error.cpp">
+      <Filter>Code</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Code\cicp_inserter\CommandLineParameters.hpp">
@@ -71,6 +74,9 @@
       <Filter>Code</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Code\cicp_inserter\FileWriter.hpp">
+      <Filter>Code</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Code\cicp_inserter\Error.hpp">
       <Filter>Code</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Projects/VisualStudio/tests.vcxproj
+++ b/Projects/VisualStudio/tests.vcxproj
@@ -160,12 +160,14 @@
   <ItemGroup>
     <ClCompile Include="..\..\Code\cicp_inserter\CICPInserter.cpp" />
     <ClCompile Include="..\..\Code\cicp_inserter\CommandLineParameters.cpp" />
+    <ClCompile Include="..\..\Code\cicp_inserter\Error.cpp" />
     <ClCompile Include="..\..\Code\cicp_inserter\FileReader.cpp" />
     <ClCompile Include="..\..\Code\cicp_inserter\FileWriter.cpp" />
     <ClCompile Include="..\..\Code\cicp_inserter\PNGParser.cpp" />
     <ClCompile Include="..\..\Code\tests\CICPInserterTest.cpp" />
     <ClCompile Include="..\..\Code\tests\CommandLineParametersTest.cpp" />
     <ClCompile Include="..\..\Code\tests\EntryPoint.cpp" />
+    <ClCompile Include="..\..\Code\tests\ErrorTest.cpp" />
     <ClCompile Include="..\..\Code\tests\FileReaderTest.cpp" />
     <ClCompile Include="..\..\Code\tests\FileWriterTest.cpp" />
     <ClCompile Include="..\..\Code\tests\PNGParserTest.cpp" />
@@ -174,11 +176,13 @@
   <ItemGroup>
     <ClInclude Include="..\..\Code\cicp_inserter\CICPInserter.hpp" />
     <ClInclude Include="..\..\Code\cicp_inserter\CommandLineParameters.hpp" />
+    <ClInclude Include="..\..\Code\cicp_inserter\Error.hpp" />
     <ClInclude Include="..\..\Code\cicp_inserter\FileReader.hpp" />
     <ClInclude Include="..\..\Code\cicp_inserter\FileWriter.hpp" />
     <ClInclude Include="..\..\Code\cicp_inserter\PNGParser.hpp" />
     <ClInclude Include="..\..\Code\tests\CICPInserterTest.hpp" />
     <ClInclude Include="..\..\Code\tests\CommandLineParametersTest.hpp" />
+    <ClInclude Include="..\..\Code\tests\ErrorTest.hpp" />
     <ClInclude Include="..\..\Code\tests\FileReaderTest.hpp" />
     <ClInclude Include="..\..\Code\tests\FileWriterTest.hpp" />
     <ClInclude Include="..\..\Code\tests\PNGParserTest.hpp" />

--- a/Projects/VisualStudio/tests.vcxproj.filters
+++ b/Projects/VisualStudio/tests.vcxproj.filters
@@ -40,6 +40,8 @@
     <ClCompile Include="..\..\Code\tests\CICPInserterTest.cpp" />
     <ClCompile Include="..\..\Code\cicp_inserter\FileWriter.cpp" />
     <ClCompile Include="..\..\Code\tests\FileWriterTest.cpp" />
+    <ClCompile Include="..\..\Code\cicp_inserter\Error.cpp" />
+    <ClCompile Include="..\..\Code\tests\ErrorTest.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Dependencies\max\Code\max\Testing\CoutResultPolicy.hpp">
@@ -61,5 +63,7 @@
     <ClInclude Include="..\..\Code\tests\CICPInserterTest.hpp" />
     <ClInclude Include="..\..\Code\cicp_inserter\FileWriter.hpp" />
     <ClInclude Include="..\..\Code\tests\FileWriterTest.hpp" />
+    <ClInclude Include="..\..\Code\cicp_inserter\Error.hpp" />
+    <ClInclude Include="..\..\Code\tests\ErrorTest.hpp" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Previously, each function which could error defined its own error type. These error types all had the same form so a templated function could print the error messages.

This commit adds a unified Error type with a non-generic print function. It also adds a generic ErrorWithCode type to allow unique error codes for each potentially-erroring function.

Additionally, some header files were missing inclusion guards. The use of templates made these problematic. Inclusion guards have been added.