### PR TITLE
Add --narrow/--full and shorthand flags

### DIFF
--- a/Code/cicp_inserter/CommandLineParameters.cpp
+++ b/Code/cicp_inserter/CommandLineParameters.cpp
@@ -15,8 +15,15 @@ namespace {
 
 	// flags
 	static const std::string_view version_string               = "--version";
+	static const std::string_view v_string                     = "-v";
 	static const std::string_view help_string                  = "--help";
+	static const std::string_view h_string                     = "-h";
 	static const std::string_view preset_string                = "--preset";
+	static const std::string_view p_string                     = "-p";
+	static const std::string_view narrow_string                = "--narrow";
+	static const std::string_view n_string                     = "-n";
+	static const std::string_view full_string                  = "--full";
+	static const std::string_view f_string                     = "-f";
 	static const std::string_view color_primaries_string       = "--color_primaries";
 	static const std::string_view transfer_function_string     = "--transfer_function";
 	static const std::string_view matrix_coefficients_string   = "--matrix_coefficients";
@@ -73,6 +80,21 @@ Example usage: cicp_inserter.exe --color_primaries 1 --transfer_function 2 --mat
 
 These can be mixed to override defaults. Values specified later override prior values.
 Example usage: cicp_inserter.exe --preset display-p3 --video_full_range_flag 0 C:\images\test.png
+
+General flags:
+	-h --help             Show help information (what you are viewing now)
+	-v --version          Show version information
+	-p --preset [value]   Use [value]'s CICP values
+	-n --narrow           Use narrow range (--video_full_range_flag 0)
+	-f --full             Use full range (--video_full_range_flag 1)
+
+Specific flags to match CICP parameter names from ITU-T H.273 (experts only):
+	   --color_primaries [value]
+	   --transfer_function [value]
+	   --matrix_coefficients [value]
+	   --video_full_range_flag [value]
+Note: Specific flags use values from ITU-T H.273. Not all values are valid.
+PNG puts further restrictions on which values are valid.
 )" << std::endl;
 	}
 
@@ -155,14 +177,25 @@ namespace CICP_Inserter {
 		}
 		for (int i = 1; i < argc - 1; i++) {
 			if (expected_state == ExpectedState::None) {
-				if (version_string.compare(argv[i]) == 0) {
+				if (version_string.compare(argv[i]) == 0 ||
+				    v_string.compare(argv[i]) == 0) {
 					print_version();
 				}
-				else if (help_string.compare(argv[i]) == 0) {
+				else if (help_string.compare(argv[i]) == 0 ||
+				         h_string.compare(argv[i]) == 0) {
 					print_help();
 				}
-				else if (preset_string.compare(argv[i]) == 0) {
+				else if (preset_string.compare(argv[i]) == 0 ||
+				         p_string.compare(argv[i]) == 0) {
 					expected_state = ExpectedState::Preset;
+				}
+				else if (narrow_string.compare(argv[i]) == 0 ||
+				         n_string.compare(argv[i]) == 0) {
+					video_full_range_flag = 0;
+				}
+				else if (full_string.compare(argv[i]) == 0 ||
+				         f_string.compare(argv[i]) == 0) {
+					video_full_range_flag = 1;
 				}
 				else if (color_primaries_string.compare(argv[i]) == 0) {
 					expected_state = ExpectedState::ColorPrimaries;

--- a/Code/tests/CommandLineParametersTest.cpp
+++ b/Code/tests/CommandLineParametersTest.cpp
@@ -10,14 +10,19 @@
 
 namespace {
 
-	static constinit char const* preset = "--preset";
+	static constinit char const* preset  = "--preset";
+	static constinit char const* narrow  = "--narrow";
+	static constinit char const* full    = "--full";
+	static constinit char const* p_string = "-p";
+	static constinit char const* n_string = "-n";
+	static constinit char const* f_string = "-f";
 
-	static constinit char const* color_primaries = "--color_primaries";
-	static constinit char const* transfer_function = "--transfer_function";
-	static constinit char const* matrix_coefficients = "--matrix_coefficients";
+	static constinit char const* color_primaries       = "--color_primaries";
+	static constinit char const* transfer_function     = "--transfer_function";
+	static constinit char const* matrix_coefficients   = "--matrix_coefficients";
 	static constinit char const* video_full_range_flag = "--video_full_range_flag";
 
-	static constinit char const* program_name = "cicp_inserter.exe";
+	static constinit char const* program_name    = "cicp_inserter.exe";
 	static constinit char const* test_image_path = "C:\\test\\image.png";
 
 } // anonymous namespace
@@ -180,6 +185,20 @@ namespace CICP_Inserter {
 			}
 		});
 
+		CommandLineParametersTestSuite.AddTest(max::Testing::Test< max::Testing::CoutResultPolicy >{ "-p bt.709 returns correct CICP values", [](max::Testing::Test< max::Testing::CoutResultPolicy >& CurrentTest, max::Testing::CoutResultPolicy const& ResultPolicy) {
+			const int argc = 4;
+			char const* argv[argc] = { program_name, p_string, "bt.709", test_image_path };
+			auto result = parse_command_line_parameters(argc, argv);
+			CurrentTest.MAX_TESTING_ASSERT(result.has_value());
+
+			CurrentTest.MAX_TESTING_ASSERT(result->color_primaries_ == 1);
+			CurrentTest.MAX_TESTING_ASSERT(result->transfer_function_ == 1);
+			CurrentTest.MAX_TESTING_ASSERT(result->matrix_coefficients_ == 0);
+			CurrentTest.MAX_TESTING_ASSERT(result->video_full_range_flag_ == 1);
+			CurrentTest.MAX_TESTING_ASSERT(result->png_file_path_ == test_image_path);
+			}
+		});
+
 		CommandLineParametersTestSuite.AddTest(max::Testing::Test< max::Testing::CoutResultPolicy >{ "--color_primaries 42 returns correct CICP values", [](max::Testing::Test< max::Testing::CoutResultPolicy >& CurrentTest, max::Testing::CoutResultPolicy const& ResultPolicy) {
 			const int argc = 4;
 			char const* argv[argc] = { program_name, color_primaries, "42", test_image_path };
@@ -257,6 +276,62 @@ namespace CICP_Inserter {
 			CurrentTest.MAX_TESTING_ASSERT(result.has_value());
 
 			CurrentTest.MAX_TESTING_ASSERT(result->color_primaries_ == 42);
+			CurrentTest.MAX_TESTING_ASSERT(result->transfer_function_ == 13);
+			CurrentTest.MAX_TESTING_ASSERT(result->matrix_coefficients_ == 0);
+			CurrentTest.MAX_TESTING_ASSERT(result->video_full_range_flag_ == 1);
+			CurrentTest.MAX_TESTING_ASSERT(result->png_file_path_ == test_image_path);
+			}
+		});
+
+		CommandLineParametersTestSuite.AddTest(max::Testing::Test< max::Testing::CoutResultPolicy >{ "-p srgb --narrow returns correct CICP values", [](max::Testing::Test< max::Testing::CoutResultPolicy >& CurrentTest, max::Testing::CoutResultPolicy const& ResultPolicy) {
+			const int argc = 5;
+			char const* argv[argc] = { program_name, preset, "srgb", narrow, test_image_path };
+			auto result = parse_command_line_parameters(argc, argv);
+			CurrentTest.MAX_TESTING_ASSERT(result.has_value());
+
+			CurrentTest.MAX_TESTING_ASSERT(result->color_primaries_ == 1);
+			CurrentTest.MAX_TESTING_ASSERT(result->transfer_function_ == 13);
+			CurrentTest.MAX_TESTING_ASSERT(result->matrix_coefficients_ == 0);
+			CurrentTest.MAX_TESTING_ASSERT(result->video_full_range_flag_ == 0);
+			CurrentTest.MAX_TESTING_ASSERT(result->png_file_path_ == test_image_path);
+			}
+		});
+
+		CommandLineParametersTestSuite.AddTest(max::Testing::Test< max::Testing::CoutResultPolicy >{ "-p srgb -n returns correct CICP values", [](max::Testing::Test< max::Testing::CoutResultPolicy >& CurrentTest, max::Testing::CoutResultPolicy const& ResultPolicy) {
+			const int argc = 5;
+			char const* argv[argc] = { program_name, preset, "srgb", n_string, test_image_path };
+			auto result = parse_command_line_parameters(argc, argv);
+			CurrentTest.MAX_TESTING_ASSERT(result.has_value());
+
+			CurrentTest.MAX_TESTING_ASSERT(result->color_primaries_ == 1);
+			CurrentTest.MAX_TESTING_ASSERT(result->transfer_function_ == 13);
+			CurrentTest.MAX_TESTING_ASSERT(result->matrix_coefficients_ == 0);
+			CurrentTest.MAX_TESTING_ASSERT(result->video_full_range_flag_ == 0);
+			CurrentTest.MAX_TESTING_ASSERT(result->png_file_path_ == test_image_path);
+			}
+		});
+
+		CommandLineParametersTestSuite.AddTest(max::Testing::Test< max::Testing::CoutResultPolicy >{ "-p srgb -n --full returns correct CICP values", [](max::Testing::Test< max::Testing::CoutResultPolicy >& CurrentTest, max::Testing::CoutResultPolicy const& ResultPolicy) {
+			const int argc = 6;
+			char const* argv[argc] = { program_name, preset, "srgb", n_string, full, test_image_path };
+			auto result = parse_command_line_parameters(argc, argv);
+			CurrentTest.MAX_TESTING_ASSERT(result.has_value());
+
+			CurrentTest.MAX_TESTING_ASSERT(result->color_primaries_ == 1);
+			CurrentTest.MAX_TESTING_ASSERT(result->transfer_function_ == 13);
+			CurrentTest.MAX_TESTING_ASSERT(result->matrix_coefficients_ == 0);
+			CurrentTest.MAX_TESTING_ASSERT(result->video_full_range_flag_ == 1);
+			CurrentTest.MAX_TESTING_ASSERT(result->png_file_path_ == test_image_path);
+			}
+		});
+
+		CommandLineParametersTestSuite.AddTest(max::Testing::Test< max::Testing::CoutResultPolicy >{ "-p srgb -n -f returns correct CICP values", [](max::Testing::Test< max::Testing::CoutResultPolicy >& CurrentTest, max::Testing::CoutResultPolicy const& ResultPolicy) {
+			const int argc = 6;
+			char const* argv[argc] = { program_name, preset, "srgb", n_string, f_string, test_image_path };
+			auto result = parse_command_line_parameters(argc, argv);
+			CurrentTest.MAX_TESTING_ASSERT(result.has_value());
+
+			CurrentTest.MAX_TESTING_ASSERT(result->color_primaries_ == 1);
 			CurrentTest.MAX_TESTING_ASSERT(result->transfer_function_ == 13);
 			CurrentTest.MAX_TESTING_ASSERT(result->matrix_coefficients_ == 0);
 			CurrentTest.MAX_TESTING_ASSERT(result->video_full_range_flag_ == 1);


### PR DESCRIPTION
This commit adds --narrow, --full, and shorthand flags like -v for --version, -p for --preset, etc.

It also updates the --help/-h message to show this and better explain the flags.

Closes #4 
Closes #23 