### PR TITLE
Update --help example

### DIFF
--- a/Code/cicp_inserter/CommandLineParameters.cpp
+++ b/Code/cicp_inserter/CommandLineParameters.cpp
@@ -49,8 +49,8 @@ Presets:
 	display-p3      Display P3
 	p3-d65-pq       P3-D65 PQ
 
-You can also specify individual CICP values.
-Example usage: cicp_inserter.exe --color_primaries 1 --transfer_function 2 --matrix_coefficients 3 --video_full_range_flag 1 C:\images\test.png
+You can also specify individual CICP values. For example, to label an RGB image decoded from a SECAM video:
+Example usage: cicp_inserter.exe --color_primaries 5 --transfer_function 4 --matrix_coefficients 0 --video_full_range_flag 1 C:\images\test.png
 
 These can be mixed to override defaults. Values specified later override prior values.
 Example usage: cicp_inserter.exe --preset display-p3 --video_full_range_flag 0 C:\images\test.png


### PR DESCRIPTION
The README.md was updated to use better CICP values in the example. But the --help text was not updated to match.

This commit updates the --help message.