### PR TITLE
Fix --help on non-Windows

### DIFF
--- a/Code/png_cicp_editor/CommandLineParameters.cpp
+++ b/Code/png_cicp_editor/CommandLineParameters.cpp
@@ -10,6 +10,8 @@
 #include <string_view>
 #include <utility>
 
+#include <max/Compiling/Configuration.hpp>
+
 #include "StateMachine.hpp"
 #include "SparseArray.hpp"
 
@@ -28,6 +30,16 @@ namespace {
 	}
 
 	void print_help() noexcept {
+		#if defined(MAX_PLATFORM_WINDOWS)
+			static constinit auto program_name = std::string_view{ "png_cicp_editor.exe" };
+			static constinit auto file_path = std::string_view{ R"(C:\images\test.png)" };
+		#elif defined(MAX_PLATFORM_LINUX) || defined(MAX_PLATFORM_MACOS)
+			static constinit auto program_name = std::string_view{ "png_cicp_editor" };
+			static constinit auto file_path = std::string_view{ R"(/images/test.png)" };
+		#else
+			static_assert( false, "Unknown platform" );
+		#endif
+
 		print_version();
 		std::cout <<
 R"(This program allows you to insert CICP data into a PNG file.
@@ -35,7 +47,7 @@ CICP is an efficient way to specify color space.
 It is standardized in ITU-T H.273, which can be found here:
 https://www.itu.int/rec/T-REC-H.273
 
-Example usage: png_cicp_editor.exe --preset display-p3 C:\images\test.png
+Example usage: )" << program_name << R"( --preset display-p3 )" << file_path << R"(
 
 Presets:
 	bt.709          Rec. ITU-R BT.709-6
@@ -50,14 +62,15 @@ Presets:
 	p3-d65-pq       P3-D65 PQ
 
 You can also specify individual CICP values. For example, to label an RGB image decoded from a SECAM video:
-Example usage: png_cicp_editor.exe --color_primaries 5 --transfer_function 4 --matrix_coefficients 0 --video_full_range_flag 1 C:\images\test.png
+Example usage: )" << program_name << R"( --color_primaries 5 --transfer_function 4 --matrix_coefficients 0 --video_full_range_flag 1 )" << file_path << R"(
 
 These can be mixed to override defaults. Values specified later override prior values.
-Example usage: png_cicp_editor.exe --preset display-p3 --video_full_range_flag 0 C:\images\test.png
+Example usage: )" << program_name << R"( --preset display-p3 --video_full_range_flag 0 )" << file_path << R"(
 
 General flags:
 	-h --help             Show help information (what you are viewing now)
 	-v --version          Show version information
+	   --license          Show license information
 	-p --preset [value]   Use [value]'s CICP values
 	-n --narrow           Use narrow range (--video_full_range_flag 0)
 	-f --full             Use full range (--video_full_range_flag 1)
@@ -70,6 +83,70 @@ Specific flags to match CICP parameter names from ITU-T H.273 (experts only):
 	   --video_full_range_flag [value]
 Note: Specific flags use values from ITU-T H.273. Not all values are valid.
 PNG puts further restrictions on which values are valid.
+)" << std::endl;
+	}
+
+	void print_license() noexcept {
+		std::cout << R"(Copyright 2025, The png_cicp_editor Contributors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+    * Neither the name of png_cicp_editor nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+png_cicp_editor depends on max:
+
+Copyright 2015, The max Contributors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+    * Neither the name of max nor the names of its contributors may be
+used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 )" << std::endl;
 	}
 
@@ -179,6 +256,17 @@ namespace PNG_CICP_Editor {
 					return false;
 				}
 				print_help();
+				return true;
+			},
+			ParserStates::Done
+		};
+		auto license_flag_matched_transition = Transition{
+			[](char const* string) -> Transition::PredicateAndActionResultType {
+				static const std::string_view license_string = "--license";
+				if (license_string.compare(string) != 0) {
+					return false;
+				}
+				print_license();
 				return true;
 			},
 			ParserStates::Done
@@ -457,6 +545,7 @@ namespace PNG_CICP_Editor {
 		auto action_found_transitions = TransitionsType{
 			std::move(version_flag_matched_transition),
 			std::move(help_flag_matched_transition),
+			std::move(license_flag_matched_transition),
 			// The following transitions are reused in the flag found transitions
 			preset_flag_matched_transition,
 			narrow_flag_matched_transition,

--- a/Code/tests/CommandLineParametersTest.cpp
+++ b/Code/tests/CommandLineParametersTest.cpp
@@ -36,7 +36,7 @@ namespace PNG_CICP_Editor {
 		max::Testing::CoutResultPolicy ResultPolicy;
 		auto CommandLineParametersTestSuite = max::Testing::TestSuite< max::Testing::CoutResultPolicy >{ "CommandLineParameters test suite", std::move(ResultPolicy) };
 
-		// TODO: Add tests for --version & --help
+		// TODO: Add tests for -v, --version, -h, --help, & --license
 
 		CommandLineParametersTestSuite.AddTest(max::Testing::Test< max::Testing::CoutResultPolicy >{ "ParseCommandLineParametersError ctor assigns members", [](max::Testing::Test< max::Testing::CoutResultPolicy >& CurrentTest, max::Testing::CoutResultPolicy const& ResultPolicy) {
 			auto error = ParseCommandLineParametersError{ ParseCommandLineParametersErrorCode::UnrecognizedParameter, { preset } };

--- a/Dependencies/max/Code/max/Compiling/Configuration.hpp
+++ b/Dependencies/max/Code/max/Compiling/Configuration.hpp
@@ -1,0 +1,20 @@
+// Copyright 2015, The max Contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef MAX_COMPILING_CONFIGURATION_HPP
+#define MAX_COMPILING_CONFIGURATION_HPP
+
+#ifndef MAX_COMPILING_CONFIGURATION_COMPILER_HPP
+	#include <max/Compiling/Configuration/Compiler.hpp>
+#endif
+
+#ifndef MAX_COMPILING_CONFIGURATION_STANDARDLIBRARY_HPP
+	#include <max/Compiling/Configuration/StandardLibrary.hpp>
+#endif
+
+#ifndef MAX_COMPILING_CONFIGURATION_PLATFORM_HPP
+	#include <max/Compiling/Configuration/Platform.hpp>
+#endif
+
+#endif // #ifndef MAX_COMPILING_CONFIGURATION_HPP

--- a/Dependencies/max/Code/max/Compiling/Configuration/Compiler.hpp
+++ b/Dependencies/max/Code/max/Compiling/Configuration/Compiler.hpp
@@ -1,0 +1,30 @@
+// Copyright 2015, The max Contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef MAX_COMPILING_CONFIGURATION_COMPILER_HPP
+#define MAX_COMPILING_CONFIGURATION_COMPILER_HPP
+
+// The order of these is important.
+// Clang defines both __clang__ and __GNUC__.
+// GCC does not define __clang__.
+// So the GCC check must come after the Clang check.
+// ICC also defines __GNUC__.
+// So the check for __ICC must also come before the GCC check.
+// Metrowerks and MSVC both define _MSC_VER.
+// So check __MWERKS__ prior to checking _MSC_VER.
+
+#if defined __clang__
+	// Clang
+	#include <max/Compiling/Configuration/Compiler/Clang.hpp>
+#elif defined __GNUC__
+	// GNU C++
+	#include <max/Compiling/Configuration/Compiler/GCC.hpp>
+#elif defined _MSC_VER
+	// Microsoft Visual C++
+	#include <max/Compiling/Configuration/Compiler/VC.hpp>
+#else
+	#error "Unknown compiler"
+#endif
+
+#endif // #ifndef MAX_COMPILING_CONFIGURATION_COMPILER_HPP

--- a/Dependencies/max/Code/max/Compiling/Configuration/Compiler/Clang.hpp
+++ b/Dependencies/max/Code/max/Compiling/Configuration/Compiler/Clang.hpp
@@ -1,0 +1,69 @@
+// Copyright 2015, The max Contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef MAX_COMPILING_CONFIGURATION_COMPILER_CLANG_HPP
+#define MAX_COMPILING_CONFIGURATION_COMPILER_CLANG_HPP
+
+#include <version>
+
+#include <max/Compiling/Macros.hpp>
+
+#define MAX_COMPILER_CLANG
+
+#define MAX_COMPILER_MESSAGE( Message ) _Pragma( MAX_STRINGIFY( message( Message ) ) )
+
+#define MAX_COMPILER_VERSION_MAJOR __clang_major__
+#define MAX_COMPILER_VERSION_MINOR __clang_minor__
+#define MAX_COMPILER_VERSION_PATCH __clang_patchlevel__
+
+#if __cplusplus > 202101L
+	MAX_COMPILER_MESSAGE( "Compiling with a newer version of C++ than max recognizes. Using last known version." );
+#elif __cplusplus >= 202101L
+	#define MAX_CPP_2B
+	#define MAX_CPP_20
+#elif __cplusplus >= 202002L
+	#define MAX_CPP_2A
+	#define MAX_CPP_20
+#elif __cplusplus >= 201703L
+	#define MAX_CPP_2A
+	#define MAX_CPP_1Z
+	#define MAX_CPP_17
+#elif __cplusplus >= 201402L
+	#define MAX_CPP_1Z
+	#define MAX_CPP_14
+#elif __cplusplus >= 201103L
+	#define MAX_CPP_11
+#elif __cplusplus >= 199711L
+	#define MAX_CPP_03
+#endif
+
+#if __has_feature(cxx_exceptions)
+	#define MAX_EXCEPTIONS_SUPPORTED
+#endif
+
+#if __has_feature(cxx_noexcept)
+	#define MAX_NOEXCEPT_SUPPORTED
+#endif
+
+#if __has_feature(cxx_inline_namespaces)
+	#define MAX_INLINE_NAMESPACES_SUPPORTED
+#endif
+
+#define MAX_INTRINSICS_ALLOWED_INSIDE_CONSTEXPR
+
+#if MAX_COMPILER_VERSION_AT_LEAST( 3, 1, 0 )
+	#define MAX_CONSTEXPR_SUPPORTED
+#endif
+
+#if ( MAX_COMPILER_VERSION_AT_LEAST( 9, 0, 0 ) && __cplusplus > 201703L ) || __cpp_lib_is_constant_evaluated
+	#define MAX_IS_CONSTANT_EVALUATED_SUPPORTED
+#endif
+
+#if MAX_COMPILER_VERSION_AT_LEAST( 10, 0, 0 )
+	#if __cpp_concepts
+		#define MAX_CONCEPTS_SUPPORTED
+	#endif
+#endif
+
+#endif // #ifndef MAX_COMPILING_CONFIGURATION_COMPILER_CLANG_HPP

--- a/Dependencies/max/Code/max/Compiling/Configuration/Compiler/GCC.hpp
+++ b/Dependencies/max/Code/max/Compiling/Configuration/Compiler/GCC.hpp
@@ -1,0 +1,78 @@
+// Copyright 2015, The max Contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef MAX_COMPILING_CONFIGURATION_COMPILER_GCC_HPP
+#define MAX_COMPILING_CONFIGURATION_COMPILER_GCC_HPP
+
+#include <version>
+
+#include <max/Compiling/Macros.hpp>
+
+#define MAX_COMPILER_GCC
+
+#define MAX_COMPILER_MESSAGE( Message ) _Pragma( MAX_STRINGIFY( message( Message ) ) )
+
+#define MAX_COMPILER_VERSION_MAJOR __GNUC__
+#define MAX_COMPILER_VERSION_MINOR __GNUC_MINOR__
+#if __GNUC__ >= 3
+	// __GNUC_PATCHLEVEL__ is new to GCC 3.0
+	#define MAX_COMPILER_VERSION_PATCH __GNUC_PATCHLEVEL__
+#else
+	#define MAX_COMPILER_VERSION_PATCH 0
+#endif
+
+
+#if __cplusplus > 202100L
+	MAX_COMPILER_MESSAGE( "Compiling with a newer version of C++ than max recognizes. Using last known version." );
+#elif __cplusplus >= 202100L
+	#define MAX_CPP_2B
+	#define MAX_CPP_20
+#elif __cplusplus >= 202002L
+	#define MAX_CPP_2A
+	#define MAX_CPP_20
+#elif __cplusplus >= 201709L
+	#define MAX_CPP_2A
+	#define MAX_CPP_17
+#elif __cplusplus >= 201703L
+	#define MAX_CPP_1Z
+	#define MAX_CPP_17
+#elif __cplusplus >= 201500L
+	#define MAX_CPP_1Z
+	#define MAX_CPP_17
+#elif __cplusplus >= 201402L
+	#define MAX_CPP_14
+#elif __cplusplus >= 201103L
+	#define MAX_CPP_11
+#elif __cplusplus >= 199711L
+	#define MAX_CPP_03
+#endif
+
+#if defined(__EXCEPTIONS)
+	#define MAX_EXCEPTIONS_SUPPORTED
+#endif
+
+#if MAX_COMPILER_VERSION_AT_LEAST( 4, 4, 0 ) && defined( __GXX_EXPERIMENTAL_CXX0X__ )
+	#define MAX_INLINE_NAMESPACES_SUPPORTED
+#endif
+
+#if MAX_COMPILER_VERSION_AT_LEAST( 4, 6, 0 )
+	#define MAX_CONSTEXPR_SUPPORTED
+	#if defined( __GXX_EXPERIMENTAL_CXX0X__ )
+		#define MAX_NOEXCEPT_SUPPORTED
+	#endif
+#endif
+
+#define MAX_INTRINSICS_ALLOWED_INSIDE_CONSTEXPR
+
+#if ( MAX_COMPILER_VERSION_AT_LEAST( 9, 0, 0 ) && defined( MAX_CPP_20 ) ) || __cpp_lib_is_constant_evaluated
+	#define MAX_IS_CONSTANT_EVALUATED_SUPPORTED
+#endif
+
+#if MAX_COMPILER_VERSION_AT_LEAST( 10, 0, 0 )
+	#if __cpp_concepts
+		#define MAX_CONCEPTS_SUPPORTED
+	#endif
+#endif
+
+#endif // #ifndef MAX_COMPILING_CONFIGURATION_COMPILER_GCC_HPP

--- a/Dependencies/max/Code/max/Compiling/Configuration/Compiler/VC.hpp
+++ b/Dependencies/max/Code/max/Compiling/Configuration/Compiler/VC.hpp
@@ -1,0 +1,305 @@
+// Copyright 2015, The max Contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef MAX_COMPILING_CONFIGURATION_COMPILER_VC_HPP
+#define MAX_COMPILING_CONFIGURATION_COMPILER_VC_HPP
+
+#include <max/Compiling/Macros.hpp>
+
+#define MAX_COMPILER_VC
+
+#define MAX_COMPILER_MESSAGE( Message ) __pragma( message( Message ) )
+
+#if _MSC_VER > 1943
+	MAX_COMPILER_MESSAGE("Compiling with a newer version of MSVC than max recognizes. Using last known version.");
+#elif _MSC_VER >= 1943
+	// MSVC++ (Visual Studio 2022 / version 17.13)
+	#define MAX_COMPILER_VERSION_MAJOR 17
+	#define MAX_COMPILER_VERSION_MINOR 13
+#elif _MSC_VER >= 1939
+	// MSVC++ (Visual Studio 2022 / version 17.9)
+	#define MAX_COMPILER_VERSION_MAJOR 17
+	#define MAX_COMPILER_VERSION_MINOR 9
+#elif _MSC_VER >= 1938
+	// MSVC++ (Visual Studio 2022 / version 17.8)
+	#define MAX_COMPILER_VERSION_MAJOR 17
+	#define MAX_COMPILER_VERSION_MINOR 8
+#elif _MSC_VER >= 1937
+	// MSVC++ (Visual Studio 2022 / version 17.7)
+	#define MAX_COMPILER_VERSION_MAJOR 17
+	#define MAX_COMPILER_VERSION_MINOR 7
+#elif _MSC_VER >= 1936
+	// MSVC++ (Visual Studio 2022 / version 17.6)
+	#define MAX_COMPILER_VERSION_MAJOR 17
+	#define MAX_COMPILER_VERSION_MINOR 6
+#elif _MSC_VER >= 1935
+	// MSVC++ (Visual Studio 2022 / version 17.5)
+	#define MAX_COMPILER_VERSION_MAJOR 17
+	#define MAX_COMPILER_VERSION_MINOR 5
+#elif _MSC_VER >= 1934
+	// MSVC++ (Visual Studio 2022 / version 17.4)
+	#define MAX_COMPILER_VERSION_MAJOR 17
+	#define MAX_COMPILER_VERSION_MINOR 4
+#elif _MSC_VER >= 1933
+	// MSVC++ (Visual Studio 2022 / version 17.3)
+	#define MAX_COMPILER_VERSION_MAJOR 17
+	#define MAX_COMPILER_VERSION_MINOR 3
+#elif _MSC_VER >= 1932
+	// MSVC++ (Visual Studio 2022 / version 17.2)
+	#define MAX_COMPILER_VERSION_MAJOR 17
+	#define MAX_COMPILER_VERSION_MINOR 2
+#elif _MSC_VER >= 1931
+	// MSVC++ (Visual Studio 2022 / version 17.1)
+	#define MAX_COMPILER_VERSION_MAJOR 17
+	#define MAX_COMPILER_VERSION_MINOR 1
+#elif _MSC_VER >= 1930
+	// MSVC++ (Visual Studio 2022 Preview 3.0 & 4.0 / version 17.0)
+	#define MAX_COMPILER_VERSION_MAJOR 17
+	#define MAX_COMPILER_VERSION_MINOR 0
+#elif _MSC_VER >= 1929
+	// MSVC++ 14.30 (Visual Studio 2019 / version 16.10)
+	// Note, 16.11 also shares this same _MSC_VER.
+	// Note, Visual Studio 2022 Preview 1.0 (and possibly 2.0?) / version 17.0 also shares this same _MSC_VER.
+	#define MAX_COMPILER_VERSION_MAJOR 16
+	#define MAX_COMPILER_VERSION_MINOR 10
+#elif _MSC_VER >= 1928
+	// MSVC++ 14.28 (Visual Studio 2019 / version 16.8)
+	// Note, 16.9 also shares this same _MSC_VER.
+	#define MAX_COMPILER_VERSION_MAJOR 16
+	#define MAX_COMPILER_VERSION_MINOR 8
+#elif _MSC_VER >= 1927
+	// MSVC++ 14.27 (Visual Studio 2019 / versoin 16.7)
+	#define MAX_COMPILER_VERSION_MAJOR 16
+	#define MAX_COMPILER_VERSION_MINOR 7
+#elif _MSC_VER >= 1926
+	// MSVC++ 14.26 (Visual Studio 2019 / version 16.6)
+	#define MAX_COMPILER_VERSION_MAJOR 16
+	#define MAX_COMPILER_VERSION_MINOR 6
+#elif _MSC_VER >= 1925
+	// MSVC++ 14.25 (Visual Studio 2019 / version 16.5)
+	#define MAX_COMPILER_VERSION_MAJOR 16
+	#define MAX_COMPILER_VERSION_MINOR 5
+#elif _MSC_VER >= 1924
+	// MSVC++ 14.24 (Visual Studio 2019 / version 16.4)
+	#define MAX_COMPILER_VERSION_MAJOR 16
+	#define MAX_COMPILER_VERSION_MINOR 4
+#elif _MSC_VER >= 1923
+	// MSVC++ 14.23 (Visual Studio 2019 / version 16.3)
+	#define MAX_COMPILER_VERSION_MAJOR 16
+	#define MAX_COMPILER_VERSION_MINOR 3
+#elif _MSC_VER >= 1922
+	// MSVC++ 14.22 (Visual Studio 2019 / version 16.2)
+	#define MAX_COMPILER_VERSION_MAJOR 16
+	#define MAX_COMPILER_VERSION_MINOR 2
+#elif _MSC_VER >= 1921
+	// MSVC++ 14.21 (Visual Studio 2019 / version 16.1)
+	#define MAX_COMPILER_VERSION_MAJOR 16
+	#define MAX_COMPILER_VERSION_MINOR 1
+#elif _MSC_VER >= 1920
+	// MSVC++ 14.2 (Visual Studio 2019 / version 16.0)
+	#define MAX_COMPILER_VERSION_MAJOR 16
+	#define MAX_COMPILER_VERSION_MINOR 0
+#elif _MSC_VER >= 1916
+	// MSVC++ 14.16 (Visual Studio 2017 Update 9 / version 15.9)
+	#define MAX_COMPILER_VERSION_MAJOR 15
+	#define MAX_COMPILER_VERSION_MINOR 9
+#elif _MSC_VER >= 1915
+	// MSVC++ 14.15 (Visual Studio 2017 Update 8 / version 15.8)
+	#define MAX_COMPILER_VERSION_MAJOR 15
+	#define MAX_COMPILER_VERSION_MINOR 8
+#elif _MSC_VER >= 1914
+	// MSVC++ 14.14 (Visual Studio 2017 Update 7 / version 15.7)
+	#define MAX_COMPILER_VERSION_MAJOR 15
+	#define MAX_COMPILER_VERSION_MINOR 7
+#elif _MSC_VER >= 1913
+	// MSVC++ 14.13 (Visual Studio 2017 Update 6 / version 15.6)
+	#define MAX_COMPILER_VERSION_MAJOR 15
+	#define MAX_COMPILER_VERSION_MINOR  6
+#elif _MSC_VER >= 1912
+	// MSVC++ 14.12 (Visual Studio 2017 Update 5 / version 15.5)
+	#define MAX_COMPILER_VERSION_MAJOR 15
+	#define MAX_COMPILER_VERSION_MINOR  5
+#elif _MSC_VER >= 1911
+	// MSVC++ 14.11 (Visual Studio 2017 Update 3 & 4 / version 15.3, 15.4)
+	#define MAX_COMPILER_VERSION_MAJOR 15
+	#define MAX_COMPILER_VERSION_MINOR  3
+#elif _MSC_VER >= 1910
+	// MSVC++ 14.1 (Visual Studio 2017 and Update 1 & 2 / version 15.0, 15.1, 15.2)
+	#define MAX_COMPILER_VERSION_MAJOR 15
+	#define MAX_COMPILER_VERSION_MINOR  0
+#elif _MSC_VER >= 1900
+	// MSVC++ 14.0 and updates 1, 2, & 3 (Visual Studio 2015 / version 14.0)
+	#define MAX_COMPILER_VERSION_MAJOR 14
+	#define MAX_COMPILER_VERSION_MINOR  0
+	// All of MSVC++ 14.0's updates show up with _MSC_VER 1900.
+	// So check _MSC_FULL_VER.
+	#if _MSC_FULL_VER >= 190024210
+		// MSVC++ 14.3 (Visual Studio 2015 Update 3)
+	#elif _MSC_FULL_VER >= 190023918
+		// MSVC++ 14.2 (Visual Studio 2015 Update 2)
+	#elif _MSC_FULL_VER >= 190023506
+		// MSVC++ 14.1 (Visual Studio 2015 Update 1)
+	#endif
+#elif _MSC_VER >= 1800
+	// MSVC++ 12.0 (Visual Studio 2013 / version 12.0)
+	#define MAX_COMPILER_VERSION_MAJOR 12
+	#define MAX_COMPILER_VERSION_MINOR  0
+#elif _MSC_VER >= 1700
+	// MSVC++ 11.0 (Visual Studio 2012 / version 11.0)
+	#define MAX_COMPILER_VERSION_MAJOR 11
+	#define MAX_COMPILER_VERSION_MINOR  0
+#elif _MSC_VER >= 1600
+	// MSVC++ 10.0 (Visual Studio 2010 / version 10.0)
+	#define MAX_COMPILER_VERSION_MAJOR 10
+	#define MAX_COMPILER_VERSION_MINOR  0
+	#if _MSC_FULL_VER >= 160040219
+		// MSVC++ 10.1 SP 1
+	#endif
+#elif _MSC_VER >= 1500
+	// MSVC++ 9.0 (Visual Studio 2008 / version 9.0)
+	#define MAX_COMPILER_VERSION_MAJOR 9
+	#define MAX_COMPILER_VERSION_MINOR 0
+	#if _MSC_FULL_VER >= 150030729
+		// MSVC++ 9.0 SP1
+	#endif
+#elif _MSC_VER >= 1400
+	// MSVC++ 8.0 (Visual Studio 2005 / version 8.0)
+	#define MAX_COMPILER_VERSION_MAJOR 8
+	#define MAX_COMPILER_VERSION_MINOR 0
+#elif _MSC_VER >= 1310
+	// MSVC++ 7.1 (Visual Studio .NET 2003 / version 7.1)
+	#define MAX_COMPILER_VERSION_MAJOR 7
+	#define MAX_COMPILER_VERSION_MINOR 1
+	#if _MSC_FULL_VER >= 13106030
+		// Visual Studio .NET 2003 SP 1
+	#elif _MSC_FULL_VER >= 13103077
+		// Visual Studio .NET 2003
+	#elif _MSC_FULL_VER >= 13102292
+		// Visual Studio .NET 2003 Beta
+	#endif
+#elif _MSC_VER >= 1300
+	// MSVC++ 7.0 (Visual Studio .NET 2002 / version 7.0)
+	#define MAX_COMPILER_VERSION_MAJOR 7
+	#define MAX_COMPILER_VERSION_MINOR 0
+#elif _MSC_VER >= 1200
+	// MSVC++ 6.0 (Visual Studio 6.0 / version 6.0)
+	#define MAX_COMPILER_VERSION_MAJOR 6
+	#define MAX_COMPILER_VERSION_MINOR 0
+	#if _MSC_FULL_VER >= 12008804
+		// MSVC++ 6.0 SP6
+	#endif
+#elif _MSC_VER >= 1100
+	// MSVC++ 5.0 (Visual Studio 97 / version 5.0)
+	#define MAX_COMPILER_VERSION_MAJOR 5
+	#define MAX_COMPILER_VERSION_MINOR 0
+#elif _MSC_VER >= 1020
+	// MSVC++ 4.2 (Developer Studio 4.2)
+	#define MAX_COMPILER_VERSION_MAJOR 4
+	#define MAX_COMPILER_VERSION_MINOR 2
+#elif _MSC_VER >= 1010
+	// MSVC++ 4.1 (Developer Studio 4.1)
+	#define MAX_COMPILER_VERSION_MAJOR 4
+	#define MAX_COMPILER_VERSION_MINOR 1
+#elif _MSC_VER >= 1000
+	// MSVC++ 4.0 (Developer Studio 4.0)
+	#define MAX_COMPILER_VERSION_MAJOR 4
+	#define MAX_COMPILER_VERSION_MINOR 0
+#elif _MSC_VER >= 900
+	// MSVC++ 2.0
+	#define MAX_COMPILER_VERSION_MAJOR 2
+	#define MAX_COMPILER_VERSION_MINOR 0
+#elif _MSC_VER >= 800
+	// MSVC++ 1.0
+	#define MAX_COMPILER_VERSION_MAJOR 1
+	#define MAX_COMPILER_VERSION_MINOR 0
+#elif _MSC_VER >= 700
+	// MSC/C++ 7.0
+	#define MAX_COMPILER_VERSION_MAJOR 7
+	#define MAX_COMPILER_VERSION_MINOR 0
+#elif _MSC_VER >= 600
+	// MSC 6.0
+	#define MAX_COMPILER_VERSION_MAJOR 6
+	#define MAX_COMPILER_VERSION_MINOR 0
+#elif _MSC_VER >= 500
+	// MSC 5.0
+	#define MAX_COMPILER_VERSION_MAJOR 5
+	#define MAX_COMPILER_VERSION_MINOR 0
+#elif _MSC_VER >= 400
+	// MSC 4.0
+	#define MAX_COMPILER_VERSION_MAJOR 4
+	#define MAX_COMPILER_VERSION_MINOR 0
+#elif _MSC_VER >= 300
+	// MSC 3.0
+	#define MAX_COMPILER_VERSION_MAJOR 3
+	#define MAX_COMPILER_VERSION_MINOR 0
+#elif _MSC_VER >= 200
+	// MSC 2.0
+	#define MAX_COMPILER_VERSION_MAJOR 2
+	#define MAX_COMPILER_VERSION_MINOR 0
+#elif _MSC_VER >= 100
+	// MSC 1.0
+	#define MAX_COMPILER_VERSION_MAJOR 1
+	#define MAX_COMPILER_VERSION_MINOR 0
+#else
+	#error "Unknown compiler version"
+#endif
+#define MAX_COMPILER_VERSION_PATCH 0
+
+#if _MSC_FULL_VER >= 190024210 // MSVC++ 14.3 (Visual Studio 2015 Update 3)
+	// Visual Studio 2015 Update 3 introduced the _MSVC_LANG pre-defined macro
+	#if _MSVC_LANG > 202400L
+		MAX_COMPILER_MESSAGE("Compiling with a newer version of C++ than max recognizes. Using last known version.");
+	#elif _MSVC_LANG >= 202400L
+		#define MAX_CPP_23
+	#elif _MSVC_LANG >= 202004L
+		#define MAX_CPP_20
+	#elif _MSVC_LANG >= 201705L
+		#define MAX_CPP_17
+	#elif _MSVC_LANG >= 201704L
+		#define MAX_CPP_17
+	#elif _MSVC_LANG >= 201703L
+		#define MAX_CPP_17
+	#elif _MSVC_LANG >= 201402L
+		#define MAX_CPP_14
+	#elif _MSVC_LANG >= 201103L
+		#define MAX_CPP_11
+	#elif _MSVC_LANG >= 199711L
+		#define MAX_CPP_03
+	#endif
+#else
+	#define MAX_CPP_03
+#endif
+
+// VC sets _CPPUNWIND on /EHsc but not /EHa ... I think?
+#if defined(_CPPUNWIND)
+	#define MAX_EXCEPTIONS_SUPPORTED
+#endif
+
+#if _MSC_FULL_VER >= 180021114
+	#define MAX_NOEXCEPT_SUPPORTED
+#endif
+
+#if MAX_COMPILER_VERSION_AT_LEAST( 14, 0, 0 )
+	#define	MAX_INLINE_NAMESPACES_SUPPORTED
+	#define MAX_CONSTEXPR_SUPPORTED
+#endif
+
+#if MAX_COMPILER_VERSION_AT_LEAST( 15, 3, 0 )
+	#define MAX_HAS_INCLUDE_SUPPORTED
+#endif
+
+#if MAX_COMPILER_VERSION_AT_LEAST( 16, 2, 0 )
+	#include <version>
+	#if ( MAX_COMPILER_VERSION_AT_LEAST( 16, 5, 0 ) && defined ( _MSVC_LANG ) && _MSVC_LANG >= 201704L ) || __cpp_lib_is_constant_evaluated
+		#define MAX_IS_CONSTANT_EVALUATED_SUPPORTED
+	#endif
+#endif
+
+#if MAX_COMPILER_VERSION_AT_LEAST( 17, 0, 0 )
+	#if __cpp_concepts
+		#define MAX_CONCEPTS_SUPPORTED
+	#endif
+#endif
+
+#endif // #ifndef MAX_COMPILING_CONFIGURATION_COMPILER_VC_HPP

--- a/Dependencies/max/Code/max/Compiling/Configuration/Platform.hpp
+++ b/Dependencies/max/Code/max/Compiling/Configuration/Platform.hpp
@@ -1,0 +1,28 @@
+// Copyright 2015, The max Contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef MAX_COMPILING_CONFIGURATION_PLATFORM_HPP
+#define MAX_COMPILING_CONFIGURATION_PLATFORM_HPP
+
+#if defined(__ANDROID__)
+	// Android
+	#include <max/Compiling/Configuration/Platform/Andoid.hpp>
+#elif defined( linux ) || defined( __linux ) || defined( __linux__ ) || defined( __GNU__ )
+	// Linux
+	#include <max/Compiling/Configuration/Platform/Linux.hpp>
+#elif defined( _WIN32 ) || defined( __WIN32__ ) || defined( WIN32 )
+	// Win32
+	#include <max/Compiling/Configuration/Platform/Win32.hpp>
+#elif defined( macintosh ) || defined( __APPLE__ ) || defined( __APPLE_CC__ )
+	// MacOS / OSX
+	#include <max/Compiling/Configuration/Platform/MacOS.hpp>
+//#elif defined( AVR )
+	// AVR Studio
+	//__AVR_ARCH__
+	//#elif defined (__AVR_AT90USB1287__)
+#else
+	#error "Unknown platform"
+#endif
+
+#endif // #ifndef MAX_COMPILING_CONFIGURATION_PLATFORM_HPP

--- a/Dependencies/max/Code/max/Compiling/Configuration/Platform/Android.hpp
+++ b/Dependencies/max/Code/max/Compiling/Configuration/Platform/Android.hpp
@@ -1,0 +1,10 @@
+// Copyright 2016, The max Contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef MAX_COMPILING_CONFIGURATION_PLATFORM_ANDROID_HPP
+#define MAX_COMPILING_CONFIGURATION_PLATFORM_ANDROID_HPP
+
+#define MAX_PLATFORM_ANDROID
+
+#endif // #ifndef MAX_COMPILING_CONFIGURATION_PLATFORM_ANDROID_HPP

--- a/Dependencies/max/Code/max/Compiling/Configuration/Platform/Linux.hpp
+++ b/Dependencies/max/Code/max/Compiling/Configuration/Platform/Linux.hpp
@@ -1,0 +1,44 @@
+// Copyright 2015, The max Contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef MAX_COMPILING_CONFIGURATION_PLATFORM_LINUX_HPP
+#define MAX_COMPILING_CONFIGURATION_PLATFORM_LINUX_HPP
+
+#include <max/Compiling/Configuration/Compiler.hpp>
+
+#define MAX_PLATFORM_LINUX
+
+#if defined( MAX_COMPILER_GCC ) || defined( MAX_COMPILER_CLANG )
+	#if defined( __x86_64__ )
+		#define MAX_64BIT_WORD_SIZE
+		#define MAX_X86_64
+	#elif defined( __i386__ )
+		#define MAX_32BIT_WORD_SIZE
+		#define MAX_X86
+	#elif defined( __IA64__ )
+		#define MAX_64BIT_WORD_SIZE
+		#define MAX_IA64
+	#elif defined( __aarch64__ )
+		#define MAX_64BIT_WORD_SIZE
+		#define MAX_AARCH64
+	#elif defined( __arm__ )
+		#define MAX_32BIT_WORD_SIZE
+		#define MAX_ARM
+	#elif defined( __thumb__ )
+		#define MAX_16BIT_WORD_SIZE
+		#define MAX_THUMB
+	#else
+		static_assert( false, "Unknown platform" );
+	#endif
+
+	#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+		#define MAX_LITTLE_ENDIAN
+	#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+		#define MAX_BIG_ENDIAN
+	#endif
+#else
+	static_assert( false, "Unknown platform" );
+#endif
+
+#endif // #ifndef MAX_COMPILING_CONFIGURATION_PLATFORM_LINUX_HPP

--- a/Dependencies/max/Code/max/Compiling/Configuration/Platform/MacOS.hpp
+++ b/Dependencies/max/Code/max/Compiling/Configuration/Platform/MacOS.hpp
@@ -1,0 +1,30 @@
+// Copyright 2015, The max Contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef MAX_COMPILING_CONFIGURATION_PLATFORM_MACOS_HPP
+#define MAX_COMPILING_CONFIGURATION_PLATFORM_MACOS_HPP
+
+#define MAX_PLATFORM_MACOS
+
+#if defined( __i386__ )
+	#define MAX_32BIT_WORD_SIZE
+	#define MAX_X86
+	#define MAX_LITTLE_ENDIAN
+#elif defined( __x86_64__ )
+	#define MAX_64BIT_WORD_SIZE
+	#define MAX_X86_64
+	#define MAX_LITTLE_ENDIAN
+#elif defined( __ppc__ )
+	#define MAX_32BIT_WORD_SIZE
+	#define MAX_PPC
+	#define MAX_BIG_ENDIAN
+#elif #defined( __ppc64__ )
+	#define MAX_64BIT_WORD_SIZE
+	#define MAX_PPC64
+	#define MAX_BIG_ENDIAN
+#else
+	static_assert( false, "Unknown platform" );
+#endif
+
+#endif // #ifndef MAX_COMPILING_CONFIGURATION_PLATFORM_MACOS_HPP

--- a/Dependencies/max/Code/max/Compiling/Configuration/Platform/MacOS.hpp
+++ b/Dependencies/max/Code/max/Compiling/Configuration/Platform/MacOS.hpp
@@ -19,10 +19,14 @@
 	#define MAX_32BIT_WORD_SIZE
 	#define MAX_PPC
 	#define MAX_BIG_ENDIAN
-#elif #defined( __ppc64__ )
+#elif defined( __ppc64__ )
 	#define MAX_64BIT_WORD_SIZE
 	#define MAX_PPC64
 	#define MAX_BIG_ENDIAN
+#elif defined( __arm64__ )
+    #define MAX_64BIT_WORD_SIZE
+    #define MAX_ARM64
+    #define MAX_LITTLE_ENDIAN
 #else
 	static_assert( false, "Unknown platform" );
 #endif

--- a/Dependencies/max/Code/max/Compiling/Configuration/Platform/Win32.hpp
+++ b/Dependencies/max/Code/max/Compiling/Configuration/Platform/Win32.hpp
@@ -1,0 +1,55 @@
+// Copyright 2015, The max Contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef MAX_CONFIGURATION_PLATFORM_WIN32_HPP
+#define MAX_CONFIGURATION_PLATFORM_WIN32_HPP
+
+#include <max/Compiling/Configuration/Compiler.hpp>
+
+#define MAX_PLATFORM_WINDOWS
+
+#if defined( MAX_COMPILER_GCC )
+	#if defined( __x86_64__ )
+		#define MAX_64BIT_WORD_SIZE
+		#define MAX_X86_64
+		#define MAX_LITTLE_ENDIAN
+	#elif defined( __i386__ )
+		#define MAX_32BIT_WORD_SIZE
+		#define MAX_X86
+		#define MAX_LITTLE_ENDIAN
+	#elif defined( __IA64__ )
+		#define MAX_64BIT_WORD_SIZE
+		#define MAX_IA64
+		#define MAX_LITTLE_ENDIAN
+	#else
+		static_assert( false, "Unknown platform" );
+	#endif
+#elif defined( MAX_COMPILER_VC )
+	#if defined( _M_X64 )
+		#define MAX_64BIT_WORD_SIZE
+		#define MAX_X86_64
+		#define MAX_LITTLE_ENDIAN
+	#elif defined( _M_IX86 )
+		#define MAX_32BIT_WORD_SIZE
+		#define MAX_X86
+		#define MAX_LITTLE_ENDIAN
+	#elif defined( _M_IA64 )
+		#define MAX_64BIT_WORD_SIZE
+		#define MAX_IA64
+		#define MAX_LITTLE_ENDIAN
+	#elif defined( _M_ARM )
+		#define MAX_32BIT_WORD_SIZE
+		#define MAX_ARM
+	#elif defined( _M_ARMT )
+		// Thumb mode
+		#define MAX_16BIT_WORD_SIZE
+		#define MAX_THUMB
+	#else
+		static_assert( false, "Unknown platform" );
+	#endif
+#else
+	static_assert( false, "Unknown platform" );
+#endif
+
+#endif // #ifndef MAX_CONFIGURATION_PLATFORM_WIN32_HPP

--- a/Dependencies/max/Code/max/Compiling/Configuration/StandardLibrary.hpp
+++ b/Dependencies/max/Code/max/Compiling/Configuration/StandardLibrary.hpp
@@ -1,0 +1,17 @@
+// Copyright 2015, The max Contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef MAX_COMPILING_CONFIGURATION_STANDARDLIBRARY_HPP
+#define MAX_COMPILING_CONFIGURATION_STANDARDLIBRARY_HPP
+
+// __AVR_LIBC_VERSION__
+
+// #define __AVR_LIBC_MAJOR__    1
+// #define __AVR_LIBC_MINOR__    6
+// #define __AVR_LIBC_REVISION__ 7
+
+// GCC ships with libstdc++
+// Clang ships with libc++
+
+#endif // #ifndef MAX_COMPILING_CONFIGURATION_STANDARDLIBRARY_HPP

--- a/Dependencies/max/Code/max/Compiling/CurrentVersionNamespace.hpp
+++ b/Dependencies/max/Code/max/Compiling/CurrentVersionNamespace.hpp
@@ -1,0 +1,24 @@
+// Copyright 2015, The max Contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef MAX_COMPILING_CURRENTVERSIONNAMESPACE_HPP
+#define MAX_COMPILING_CURRENTVERSIONNAMESPACE_HPP
+
+// Note: These two macro definitions do not behave identically.
+// Inline namespaces from C++11 allow templated types to be specialized
+// from their included namespace. Using namespace does not allow that.
+// Additionally, the parent namespace is included in ADL with
+// inline namespaces.
+
+#include <max/Compiling/Configuration/Compiler.hpp>
+
+#ifndef MAX_INLINE_NAMESPACES_SUPPORTED
+	#define MAX_CURRENT_VERSION_NAMESPACE_BEGIN( Name ) inline namespace Name
+	#define MAX_CURRENT_VERSION_NAMESPACE_END( Name )
+#else
+	#define MAX_CURRENT_VERSION_NAMESPACE_BEGIN( Name ) namespace Name
+	#define MAX_CURRENT_VERSION_NAMESPACE_END( Name )   using namespace Name;
+#endif
+
+#endif // #ifndef MAX_COMPILING_CURRENTVERSIONNAMESPACE_HPP

--- a/Dependencies/max/Code/max/Compiling/Macros.hpp
+++ b/Dependencies/max/Code/max/Compiling/Macros.hpp
@@ -1,0 +1,19 @@
+// Copyright 2019, The max Contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef MAX_COMPILING_MACROS_HPP
+#define MAX_COMPILING_MACROS_HPP
+
+
+// Documentation: Macros.md
+
+#define MAX_STRINGIFY(Message) #Message
+#define MAX_EXPAND_AND_STRINGIFY(Message) MAX_STRINGIFY(Message)
+
+#define MAX_COMPILER_VERSION_AT_LEAST( Major, Minor, Patch ) \
+	( ( MAX_COMPILER_VERSION_MAJOR > (Major) ) || \
+	  ( MAX_COMPILER_VERSION_MAJOR == (Major) && MAX_COMPILER_VERSION_MINOR > (Minor) ) || \
+	  ( MAX_COMPILER_VERSION_MAJOR == (Major) && MAX_COMPILER_VERSION_MINOR == (Minor) && MAX_COMPILER_VERSION_PATCH >= (Patch) ) )
+
+#endif // #ifndef MAX_COMPILING_MACROS_HPP

--- a/Docs/README.md
+++ b/Docs/README.md
@@ -42,7 +42,7 @@ If png_cicp_editor is missing a feature you need, submit a [feature request](htt
 
 ## Dependencies
 
-png_cicp_editor has no dependencies beyond the C and C++ standard libraries. However, the tests depend on [max](https://github.com/ProgramMax/max), which also has a [BSD 3-Clause license](https://github.com/ProgramMax/max/blob/master/LICENSE).
+png_cicp_editor and its tests depend on [max](https://github.com/ProgramMax/max), which also has a [BSD 3-Clause license](https://github.com/ProgramMax/max/blob/master/LICENSE).
 You can find some parts of max under [Dependencies/max](https://github.com/ProgramMax/png_cicp_editor/blob/master/Dependencies/max).
 
 ## Engage

--- a/Projects/VisualStudio/png_cicp_editor.vcxproj
+++ b/Projects/VisualStudio/png_cicp_editor.vcxproj
@@ -26,6 +26,8 @@
     <None Include="..\..\AUTHORS" />
     <None Include="..\..\Code\png_cicp_editor\SparseArray.inl" />
     <None Include="..\..\Code\png_cicp_editor\StateMachine.inl" />
+    <None Include="..\..\Dependencies\max\AUTHORS" />
+    <None Include="..\..\Dependencies\max\LICENSE" />
     <None Include="..\..\Docs\code_of_conduct.md" />
     <None Include="..\..\Docs\README.md" />
     <None Include="..\..\LICENSE" />
@@ -50,6 +52,19 @@
     <ClInclude Include="..\..\Code\png_cicp_editor\PNGParser.hpp" />
     <ClInclude Include="..\..\Code\png_cicp_editor\SparseArray.hpp" />
     <ClInclude Include="..\..\Code\png_cicp_editor\StateMachine.hpp" />
+    <ClInclude Include="..\..\Dependencies\max\Code\max\Compiling\Configuration.hpp" />
+    <ClInclude Include="..\..\Dependencies\max\Code\max\Compiling\Configuration\Compiler.hpp" />
+    <ClInclude Include="..\..\Dependencies\max\Code\max\Compiling\Configuration\Compiler\Clang.hpp" />
+    <ClInclude Include="..\..\Dependencies\max\Code\max\Compiling\Configuration\Compiler\GCC.hpp" />
+    <ClInclude Include="..\..\Dependencies\max\Code\max\Compiling\Configuration\Compiler\VC.hpp" />
+    <ClInclude Include="..\..\Dependencies\max\Code\max\Compiling\Configuration\Platform.hpp" />
+    <ClInclude Include="..\..\Dependencies\max\Code\max\Compiling\Configuration\Platform\Android.hpp" />
+    <ClInclude Include="..\..\Dependencies\max\Code\max\Compiling\Configuration\Platform\Linux.hpp" />
+    <ClInclude Include="..\..\Dependencies\max\Code\max\Compiling\Configuration\Platform\MacOS.hpp" />
+    <ClInclude Include="..\..\Dependencies\max\Code\max\Compiling\Configuration\Platform\Win32.hpp" />
+    <ClInclude Include="..\..\Dependencies\max\Code\max\Compiling\Configuration\StandardLibrary.hpp" />
+    <ClInclude Include="..\..\Dependencies\max\Code\max\Compiling\CurrentVersionNamespace.hpp" />
+    <ClInclude Include="..\..\Dependencies\max\Code\max\Compiling\Macros.hpp" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>17.0</VCProjectVersion>
@@ -106,18 +121,22 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <OutDir>$(SolutionDir)\$(MSBuildProjectName)\$(PlatformTarget)\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)\$(MSBuildProjectName)\$(PlatformTarget)\$(Configuration)\</IntDir>
+    <IncludePath>$(ProjectDir)..\..\Dependencies\max\Code;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <OutDir>$(SolutionDir)\$(MSBuildProjectName)\$(PlatformTarget)\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)\$(MSBuildProjectName)\$(PlatformTarget)\$(Configuration)\</IntDir>
+    <IncludePath>$(ProjectDir)..\..\Dependencies\max\Code;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <OutDir>$(SolutionDir)\$(MSBuildProjectName)\$(PlatformTarget)\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)\$(MSBuildProjectName)\$(PlatformTarget)\$(Configuration)\</IntDir>
+    <IncludePath>$(ProjectDir)..\..\Dependencies\max\Code;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <OutDir>$(SolutionDir)\$(MSBuildProjectName)\$(PlatformTarget)\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)\$(MSBuildProjectName)\$(PlatformTarget)\$(Configuration)\</IntDir>
+    <IncludePath>$(ProjectDir)..\..\Dependencies\max\Code;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/Projects/VisualStudio/png_cicp_editor.vcxproj.filters
+++ b/Projects/VisualStudio/png_cicp_editor.vcxproj.filters
@@ -1,0 +1,101 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="..\..\Code\png_cicp_editor\CICPCreator.cpp" />
+    <ClCompile Include="..\..\Code\png_cicp_editor\CICPInserter.cpp" />
+    <ClCompile Include="..\..\Code\png_cicp_editor\CommandLineParameters.cpp" />
+    <ClCompile Include="..\..\Code\png_cicp_editor\EntryPoint.cpp" />
+    <ClCompile Include="..\..\Code\png_cicp_editor\Error.cpp" />
+    <ClCompile Include="..\..\Code\png_cicp_editor\FileReader.cpp" />
+    <ClCompile Include="..\..\Code\png_cicp_editor\FileWriter.cpp" />
+    <ClCompile Include="..\..\Code\png_cicp_editor\PNGParser.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\Code\png_cicp_editor\CICPCreator.hpp" />
+    <ClInclude Include="..\..\Code\png_cicp_editor\CICPInserter.hpp" />
+    <ClInclude Include="..\..\Code\png_cicp_editor\CommandLineParameters.hpp" />
+    <ClInclude Include="..\..\Code\png_cicp_editor\Error.hpp" />
+    <ClInclude Include="..\..\Code\png_cicp_editor\FileReader.hpp" />
+    <ClInclude Include="..\..\Code\png_cicp_editor\FileWriter.hpp" />
+    <ClInclude Include="..\..\Code\png_cicp_editor\PNGParser.hpp" />
+    <ClInclude Include="..\..\Code\png_cicp_editor\SparseArray.hpp" />
+    <ClInclude Include="..\..\Code\png_cicp_editor\StateMachine.hpp" />
+    <ClInclude Include="..\..\Dependencies\max\Code\max\Compiling\Configuration.hpp">
+      <Filter>Dependencies\max\Compiling</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Dependencies\max\Code\max\Compiling\CurrentVersionNamespace.hpp">
+      <Filter>Dependencies\max\Compiling</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Dependencies\max\Code\max\Compiling\Macros.hpp">
+      <Filter>Dependencies\max\Compiling</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Dependencies\max\Code\max\Compiling\Configuration\Compiler.hpp">
+      <Filter>Dependencies\max\Compiling\Configuration</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Dependencies\max\Code\max\Compiling\Configuration\Platform.hpp">
+      <Filter>Dependencies\max\Compiling\Configuration</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Dependencies\max\Code\max\Compiling\Configuration\StandardLibrary.hpp">
+      <Filter>Dependencies\max\Compiling\Configuration</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Dependencies\max\Code\max\Compiling\Configuration\Platform\Android.hpp">
+      <Filter>Dependencies\max\Compiling\Configuration\Platform</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Dependencies\max\Code\max\Compiling\Configuration\Platform\Linux.hpp">
+      <Filter>Dependencies\max\Compiling\Configuration\Platform</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Dependencies\max\Code\max\Compiling\Configuration\Platform\MacOS.hpp">
+      <Filter>Dependencies\max\Compiling\Configuration\Platform</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Dependencies\max\Code\max\Compiling\Configuration\Platform\Win32.hpp">
+      <Filter>Dependencies\max\Compiling\Configuration\Platform</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Dependencies\max\Code\max\Compiling\Configuration\Compiler\Clang.hpp">
+      <Filter>Dependencies\max\Compiling\Configuration\Compiler</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Dependencies\max\Code\max\Compiling\Configuration\Compiler\GCC.hpp">
+      <Filter>Dependencies\max\Compiling\Configuration\Compiler</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Dependencies\max\Code\max\Compiling\Configuration\Compiler\VC.hpp">
+      <Filter>Dependencies\max\Compiling\Configuration\Compiler</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\.github\ISSUE_TEMPLATE\bug_report.md" />
+    <None Include="..\..\.github\ISSUE_TEMPLATE\feature_request.md" />
+    <None Include="..\..\.github\workflows\build-and-test.yaml" />
+    <None Include="..\..\.gitignore" />
+    <None Include="..\..\AUTHORS" />
+    <None Include="..\..\Code\png_cicp_editor\SparseArray.inl" />
+    <None Include="..\..\Code\png_cicp_editor\StateMachine.inl" />
+    <None Include="..\..\Docs\code_of_conduct.md" />
+    <None Include="..\..\Docs\README.md" />
+    <None Include="..\..\LICENSE" />
+    <None Include="..\..\Dependencies\max\AUTHORS">
+      <Filter>Dependencies\max</Filter>
+    </None>
+    <None Include="..\..\Dependencies\max\LICENSE">
+      <Filter>Dependencies\max</Filter>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Filter Include="Dependencies">
+      <UniqueIdentifier>{9491087b-ba77-42aa-b90e-b4f4bda5a415}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Dependencies\max">
+      <UniqueIdentifier>{ab47c8e2-c480-43d8-95ab-627d57d2016a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Dependencies\max\Compiling">
+      <UniqueIdentifier>{813b2f64-8891-48ee-a59d-946977fa04df}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Dependencies\max\Compiling\Configuration">
+      <UniqueIdentifier>{4a6257d8-62e5-4226-a464-b8731de52f6a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Dependencies\max\Compiling\Configuration\Compiler">
+      <UniqueIdentifier>{d518904b-b99f-4351-a11e-e5ffb072538e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Dependencies\max\Compiling\Configuration\Platform">
+      <UniqueIdentifier>{c077ab64-27ce-490a-8b2d-fe11fbe50f61}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+</Project>

--- a/Projects/XCode/png_cicp_editor/png_cicp_editor.xcodeproj/project.pbxproj
+++ b/Projects/XCode/png_cicp_editor/png_cicp_editor.xcodeproj/project.pbxproj
@@ -34,6 +34,19 @@
 		8674B6442D8BE4E00084039B /* SparseArray.inl */ = {isa = PBXFileReference; lastKnownFileType = text; name = SparseArray.inl; path = ../../../Code/png_cicp_editor/SparseArray.inl; sourceTree = "<absolute>"; };
 		8674B6452D8BE4E00084039B /* StateMachine.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; name = StateMachine.hpp; path = ../../../Code/png_cicp_editor/StateMachine.hpp; sourceTree = "<absolute>"; };
 		8674B6462D8BE4E00084039B /* StateMachine.inl */ = {isa = PBXFileReference; lastKnownFileType = text; name = StateMachine.inl; path = ../../../Code/png_cicp_editor/StateMachine.inl; sourceTree = "<absolute>"; };
+		86E65CF52D8D82A3000A0737 /* Compiler.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; name = Compiler.hpp; path = ../../../Dependencies/max/Code/max/Compiling/Configuration/Compiler.hpp; sourceTree = "<absolute>"; };
+		86E65CF62D8D82A3000A0737 /* Platform.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; name = Platform.hpp; path = ../../../Dependencies/max/Code/max/Compiling/Configuration/Platform.hpp; sourceTree = "<absolute>"; };
+		86E65CF72D8D82A3000A0737 /* StandardLibrary.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; name = StandardLibrary.hpp; path = ../../../Dependencies/max/Code/max/Compiling/Configuration/StandardLibrary.hpp; sourceTree = "<absolute>"; };
+		86E65CFA2D8D82D4000A0737 /* Clang.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; name = Clang.hpp; path = ../../../Dependencies/max/Code/max/Compiling/Configuration/Compiler/Clang.hpp; sourceTree = "<absolute>"; };
+		86E65CFB2D8D82D4000A0737 /* GCC.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; name = GCC.hpp; path = ../../../Dependencies/max/Code/max/Compiling/Configuration/Compiler/GCC.hpp; sourceTree = "<absolute>"; };
+		86E65CFC2D8D82D4000A0737 /* VC.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; name = VC.hpp; path = ../../../Dependencies/max/Code/max/Compiling/Configuration/Compiler/VC.hpp; sourceTree = "<absolute>"; };
+		86E65CFD2D8D82F5000A0737 /* Android.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; name = Android.hpp; path = ../../../Dependencies/max/Code/max/Compiling/Configuration/Platform/Android.hpp; sourceTree = "<absolute>"; };
+		86E65CFE2D8D82F5000A0737 /* Linux.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; name = Linux.hpp; path = ../../../Dependencies/max/Code/max/Compiling/Configuration/Platform/Linux.hpp; sourceTree = "<absolute>"; };
+		86E65CFF2D8D82F5000A0737 /* MacOS.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; name = MacOS.hpp; path = ../../../Dependencies/max/Code/max/Compiling/Configuration/Platform/MacOS.hpp; sourceTree = "<absolute>"; };
+		86E65D002D8D82F5000A0737 /* Win32.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; name = Win32.hpp; path = ../../../Dependencies/max/Code/max/Compiling/Configuration/Platform/Win32.hpp; sourceTree = "<absolute>"; };
+		86E65D012D8D8313000A0737 /* Configuration.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; name = Configuration.hpp; path = ../../../Dependencies/max/Code/max/Compiling/Configuration.hpp; sourceTree = "<absolute>"; };
+		86E65D022D8D8313000A0737 /* CurrentVersionNamespace.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; name = CurrentVersionNamespace.hpp; path = ../../../Dependencies/max/Code/max/Compiling/CurrentVersionNamespace.hpp; sourceTree = "<absolute>"; };
+		86E65D032D8D8313000A0737 /* Macros.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; name = Macros.hpp; path = ../../../Dependencies/max/Code/max/Compiling/Macros.hpp; sourceTree = "<absolute>"; };
 		86FEEDF62D73CC1D00165D7F /* png_cicp_editor */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = png_cicp_editor; sourceTree = BUILT_PRODUCTS_DIR; };
 		86FEEE2C2D73CCF000165D7F /* CICPCreator.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; name = CICPCreator.hpp; path = ../../../Code/png_cicp_editor/CICPCreator.hpp; sourceTree = "<absolute>"; };
 		86FEEE2D2D73CCF000165D7F /* CICPCreator.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = CICPCreator.cpp; path = ../../../Code/png_cicp_editor/CICPCreator.cpp; sourceTree = "<absolute>"; };
@@ -63,9 +76,70 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		86E65CF12D8D8253000A0737 /* Dependencies */ = {
+			isa = PBXGroup;
+			children = (
+				86E65CF22D8D8261000A0737 /* max */,
+			);
+			path = Dependencies;
+			sourceTree = "<group>";
+		};
+		86E65CF22D8D8261000A0737 /* max */ = {
+			isa = PBXGroup;
+			children = (
+				86E65CF32D8D826C000A0737 /* Compiling */,
+			);
+			path = max;
+			sourceTree = "<group>";
+		};
+		86E65CF32D8D826C000A0737 /* Compiling */ = {
+			isa = PBXGroup;
+			children = (
+				86E65CF42D8D8273000A0737 /* Configuration */,
+				86E65D012D8D8313000A0737 /* Configuration.hpp */,
+				86E65D022D8D8313000A0737 /* CurrentVersionNamespace.hpp */,
+				86E65D032D8D8313000A0737 /* Macros.hpp */,
+			);
+			path = Compiling;
+			sourceTree = "<group>";
+		};
+		86E65CF42D8D8273000A0737 /* Configuration */ = {
+			isa = PBXGroup;
+			children = (
+				86E65CF82D8D82A6000A0737 /* Compiler */,
+				86E65CF92D8D82AE000A0737 /* Platform */,
+				86E65CF52D8D82A3000A0737 /* Compiler.hpp */,
+				86E65CF62D8D82A3000A0737 /* Platform.hpp */,
+				86E65CF72D8D82A3000A0737 /* StandardLibrary.hpp */,
+			);
+			path = Configuration;
+			sourceTree = "<group>";
+		};
+		86E65CF82D8D82A6000A0737 /* Compiler */ = {
+			isa = PBXGroup;
+			children = (
+				86E65CFA2D8D82D4000A0737 /* Clang.hpp */,
+				86E65CFB2D8D82D4000A0737 /* GCC.hpp */,
+				86E65CFC2D8D82D4000A0737 /* VC.hpp */,
+			);
+			path = Compiler;
+			sourceTree = "<group>";
+		};
+		86E65CF92D8D82AE000A0737 /* Platform */ = {
+			isa = PBXGroup;
+			children = (
+				86E65CFD2D8D82F5000A0737 /* Android.hpp */,
+				86E65CFE2D8D82F5000A0737 /* Linux.hpp */,
+				86E65CFF2D8D82F5000A0737 /* MacOS.hpp */,
+				86E65D002D8D82F5000A0737 /* Win32.hpp */,
+			);
+			path = Platform;
+			sourceTree = "<group>";
+		};
 		86FEEDED2D73CC1D00165D7F = {
 			isa = PBXGroup;
 			children = (
+				86E65CF12D8D8253000A0737 /* Dependencies */,
 				86FEEE2C2D73CCF000165D7F /* CICPCreator.hpp */,
 				86FEEE2D2D73CCF000165D7F /* CICPCreator.cpp */,
 				86FEEE2E2D73CCF000165D7F /* CICPInserter.hpp */,


### PR DESCRIPTION
The --help command prints png_cicp_editor.exe (a Windows-ism) and uses Windows file paths.

This commit shows appropriate content based on which platform png_cicp_editor is built for.
A result of this is the inclusion of max as a dependency so it can detect the target platform.