### PR TITLE
Add Rec. 601

### DIFF
--- a/Code/png_cicp_editor/Actions.cpp
+++ b/Code/png_cicp_editor/Actions.cpp
@@ -81,6 +81,8 @@ https://www.itu.int/rec/T-REC-H.273
 Example usage: )" << program_name << R"( add --preset display-p3 )" << file_path << R"(
 
 Presets:
+	bt.601-pal      Rec. ITU-R BT.601 625-line 50 Hz (PAL)
+	bt.601-ntsc     Rec. ITU-R BT.601 525-line 60 Hz (NTSC)
 	bt.709          Rec. ITU-R BT.709-6
 	srgb-linear     linear-light sRGB
 	srgb            IEC 61966-2-1 sRGB

--- a/Code/png_cicp_editor/CommandLineParameters.cpp
+++ b/Code/png_cicp_editor/CommandLineParameters.cpp
@@ -237,6 +237,30 @@ namespace PNG_CICP_Editor {
 			},
 			ParserStates::Done
 		};
+		auto bt601_pal_value_matched_transition = Transition{
+			[&](char const* string) -> Transition::PredicateAndActionResultType {
+				static const std::string_view bt601_pal_string = "bt.601-pal";
+				if (bt601_pal_string.compare(string) != 0) {
+					return false;
+				}
+				cicp.color_primaries_ = 5;
+				cicp.transfer_function_ = 6;
+				return true;
+			},
+			ParserStates::ExpectingFlagOrFile
+		};
+		auto bt601_ntsc_value_matched_transition = Transition{
+			[&](char const* string) -> Transition::PredicateAndActionResultType {
+				static const std::string_view bt601_ntsc_string = "bt.601-ntsc";
+				if (bt601_ntsc_string.compare(string) != 0) {
+					return false;
+				}
+				cicp.color_primaries_ = 6;
+				cicp.transfer_function_ = 6;
+				return true;
+			},
+			ParserStates::ExpectingFlagOrFile
+		};
 		auto bt709_value_matched_transition = Transition{
 			[&](char const* string) -> Transition::PredicateAndActionResultType {
 				static const std::string_view bt709_string = "bt.709";
@@ -466,6 +490,8 @@ namespace PNG_CICP_Editor {
 			file_found_transition,
 		};
 		auto preset_value_found_transitions = TransitionsType{
+			std::move(bt601_pal_value_matched_transition),
+			std::move(bt601_ntsc_value_matched_transition),
 			std::move(bt709_value_matched_transition),
 			std::move(linear_light_srgb_value_matched_transition),
 			std::move(srgb_value_matched_transition),

--- a/Code/tests/CommandLineParametersTest.cpp
+++ b/Code/tests/CommandLineParametersTest.cpp
@@ -98,6 +98,38 @@ namespace PNG_CICP_Editor {
 			}
 		});
 
+		CommandLineParametersTestSuite.AddTest(max::Testing::Test< max::Testing::CoutResultPolicy >{ "--preset bt.601-pal returns correct CICP values", [](max::Testing::Test< max::Testing::CoutResultPolicy >& CurrentTest, max::Testing::CoutResultPolicy const& ResultPolicy) {
+			const int argc = 5;
+			char const* argv[argc] = { program_name, add, preset, "bt.601-pal", test_image_path };
+			auto result = parse_command_line_parameters(argc, argv);
+			CurrentTest.MAX_TESTING_ASSERT(result.has_value());
+
+			CurrentTest.MAX_TESTING_ASSERT(result->action_type_ == Actions::Add);
+
+			CurrentTest.MAX_TESTING_ASSERT(result->action_.add_.cicp_.color_primaries_ == 5);
+			CurrentTest.MAX_TESTING_ASSERT(result->action_.add_.cicp_.transfer_function_ == 6);
+			CurrentTest.MAX_TESTING_ASSERT(result->action_.add_.cicp_.matrix_coefficients_ == 0);
+			CurrentTest.MAX_TESTING_ASSERT(result->action_.add_.cicp_.video_full_range_flag_ == 1);
+			CurrentTest.MAX_TESTING_ASSERT(result->action_.add_.file_path_ == test_image_path);
+			}
+		});
+
+		CommandLineParametersTestSuite.AddTest(max::Testing::Test< max::Testing::CoutResultPolicy >{ "--preset bt.601-ntsc returns correct CICP values", [](max::Testing::Test< max::Testing::CoutResultPolicy >& CurrentTest, max::Testing::CoutResultPolicy const& ResultPolicy) {
+			const int argc = 5;
+			char const* argv[argc] = { program_name, add, preset, "bt.601-ntsc", test_image_path };
+			auto result = parse_command_line_parameters(argc, argv);
+			CurrentTest.MAX_TESTING_ASSERT(result.has_value());
+
+			CurrentTest.MAX_TESTING_ASSERT(result->action_type_ == Actions::Add);
+
+			CurrentTest.MAX_TESTING_ASSERT(result->action_.add_.cicp_.color_primaries_ == 6);
+			CurrentTest.MAX_TESTING_ASSERT(result->action_.add_.cicp_.transfer_function_ == 6);
+			CurrentTest.MAX_TESTING_ASSERT(result->action_.add_.cicp_.matrix_coefficients_ == 0);
+			CurrentTest.MAX_TESTING_ASSERT(result->action_.add_.cicp_.video_full_range_flag_ == 1);
+			CurrentTest.MAX_TESTING_ASSERT(result->action_.add_.file_path_ == test_image_path);
+			}
+		});
+
 		CommandLineParametersTestSuite.AddTest(max::Testing::Test< max::Testing::CoutResultPolicy >{ "--preset bt.709 returns correct CICP values", [](max::Testing::Test< max::Testing::CoutResultPolicy >& CurrentTest, max::Testing::CoutResultPolicy const& ResultPolicy) {
 			const int argc = 5;
 			char const* argv[argc] = { program_name, add, preset, "bt.709", test_image_path };

--- a/Docs/README.md
+++ b/Docs/README.md
@@ -18,6 +18,8 @@ This command updates the file to use Display P3.
 
 | Preset         | Specification                                                            |
 |----------------|--------------------------------------------------------------------------|
+| bt.601-pal     | Rec. ITU-R BT.601 625-line 50 Hz (PAL)                                   |
+| bt.601-ntsc    | Rec. ITU-R BT.601 525-line 60 Hz (NTSC)                                  |
 | bt.709         | Rec. ITU-R BT.709-6                                                      |
 | srgb-linear    | linear-light sRGB                                                        |
 | srgb           | IEC 61966-2-1 sRGB                                                       |


### PR DESCRIPTION
This commit adds ITU-R BT.601 (both PAL and NTSC) to the presets.

Closes #61